### PR TITLE
Add a check for the maths library for proper linking when using gold

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -455,6 +455,8 @@ fi
 
 AM_CONDITIONAL([ENABLE_PYTHON],[test "x$enable_python" = "xyes"])
 
+AC_SEARCH_LIBS([floor],[m])
+
 AC_CONFIG_FILES([
 Makefile
 src/Makefile


### PR DESCRIPTION
Since we use maths, we need to add -lm in order for linking to occur properly with gold.

Signed-off-by: Steev Klimaszewski steev@gentoo.org
