### PR TITLE
replace direct struct access with accessor functions

### DIFF
--- a/cut-n-paste/toolbar-editor/egg-editable-toolbar.c
+++ b/cut-n-paste/toolbar-editor/egg-editable-toolbar.c
@@ -688,11 +688,11 @@ toolbar_drag_data_received_cb (GtkToolbar         *toolbar,
         {
           gint tpos = get_toolbar_position (etoolbar, GTK_WIDGET (toolbar));
           egg_toolbars_model_add_item (etoolbar->priv->model, tpos, ipos, name);
-          gtk_drag_finish (context, TRUE, context->action == GDK_ACTION_MOVE, time);
+          gtk_drag_finish (context, TRUE, gdk_drag_context_get_selected_action (context) == GDK_ACTION_MOVE, time);
         }
       else
         {
-          gtk_drag_finish (context, FALSE, context->action == GDK_ACTION_MOVE, time);
+          gtk_drag_finish (context, FALSE, gdk_drag_context_get_selected_action (context) == GDK_ACTION_MOVE, time);
         }
     }
 
@@ -751,7 +751,7 @@ toolbar_drag_motion_cb (GtkToolbar         *toolbar,
                                            etoolbar->priv->dnd_toolitem, ipos);
     }
 
-  gdk_drag_status (context, context->suggested_action, time);
+  gdk_drag_status (context, gdk_drag_context_get_suggested_action (context), time);
 
   return TRUE;
 }

--- a/src/eom-window.c
+++ b/src/eom-window.c
@@ -4182,7 +4182,7 @@ eom_window_drag_data_received (GtkWidget *widget,
         if (!gtk_targets_include_uri (&target, 1))
                 return;
 
-        if (context->suggested_action == GDK_ACTION_COPY) {
+        if (gdk_drag_context_get_suggested_action (context) == GDK_ACTION_COPY) {
                 window = EOM_WINDOW (widget);
 
                 file_list = eom_util_parse_uri_string_list_to_file_list ((const gchar *) gtk_selection_data_get_data (selection_data));


### PR DESCRIPTION
replace direct struct access with accessor functions in order to make it build with GSEAL_ENABLE. This is a requirement for future GTK3 support.
