### PR TITLE
Update scrollbars when display is resized in "normal size" mode (seems to fix bug #18)

### DIFF
--- a/src/eom-scroll-view.c
+++ b/src/eom-scroll-view.c
@@ -286,6 +286,7 @@ update_scrollbar_values (EomScrollView *view)
 	if (gtk_widget_get_visible (GTK_WIDGET (priv->hbar))) {
 		/* Set scroll increments */
 		page_size = MIN (scaled_width, allocation.width);
+
 		page_increment = allocation.width / 2;
 		step_increment = SCROLL_STEP_SIZE;
 
@@ -293,7 +294,9 @@ update_scrollbar_values (EomScrollView *view)
 		lower = 0;
 		upper = scaled_width;
 		xofs = CLAMP (priv->xofs, 0, upper - page_size);
-		if (gtk_adjustment_get_value (priv->hadj) != xofs) {
+
+		if (gtk_adjustment_get_value (priv->hadj) != xofs
+		     || gtk_adjustment_get_page_size (priv->hadj) != page_size) {
 			value = xofs;
 			priv->xofs = xofs;
 
@@ -320,7 +323,8 @@ update_scrollbar_values (EomScrollView *view)
 		upper = scaled_height;
 		yofs = CLAMP (priv->yofs, 0, upper - page_size);
 
-		if (gtk_adjustment_get_value (priv->vadj) != yofs) {
+		if (gtk_adjustment_get_value (priv->vadj) != yofs
+		     || gtk_adjustment_get_page_size (priv->vadj) != page_size) {
 			value = yofs;
 			priv->yofs = yofs;
 


### PR DESCRIPTION
In eom, if you set the view mode to "normal size" i.e. where the zoom is fixed to 100%, 
then make your window smaller, in some cases, the scrollbars would not update to 
match the new size. They stayed at their previous larger size, so some parts of the image 
became inaccessible.

This seems to fix bug #18.

Some screenshots:

Full-sized window before the fix:
![](https://sites.google.com/site/bl0ckeduserssoftware/scroll1.png)

Reduced-sized window before the fix, with incorrect scrollbars that are too big:
![](https://sites.google.com/site/bl0ckeduserssoftware/scrollbug2.png)

Reduced-sized window after the fix -- now you get to the previously inaccessible parts:
![](https://sites.google.com/site/bl0ckeduserssoftware/scrollbug3.png)

The test case image is at:
https://sites.google.com/site/bl0ckeduserssoftware/scrollbug.png?attredirects=0&d=1
