### PR TITLE
Add libutil to PYTHON_LIBS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -396,7 +396,7 @@ fi
 if test "x$have_python" != "xno"; then
 	PY_PREFIX=`$PYTHON -c 'import sys ; print sys.prefix'`
 	PY_EXEC_PREFIX=`$PYTHON -c 'import sys ; print sys.exec_prefix'`
-	PYTHON_LIBS="-lpython$PYTHON_VERSION"
+	PYTHON_LIBS="-lpython$PYTHON_VERSION -lutil"
 	PYTHON_LIB_LOC="-L$PY_EXEC_PREFIX/lib/python$PYTHON_VERSION/config"
 	PYTHON_CFLAGS="-I$PY_PREFIX/include/python$PYTHON_VERSION"
 	PYTHON_MAKEFILE="$libdir/python$PYTHON_VERSION/config/Makefile"


### PR DESCRIPTION
to prevent possible "undefined reference to `forkpty'" and "undefined reference to `openpty'" linker errors