### PR TITLE
fix a eom-critical + deprecated follow-state property

### DIFF
--- a/src/eom-thumb-view.c
+++ b/src/eom-thumb-view.c
@@ -102,7 +102,9 @@ eom_thumb_view_constructed (GObject *object)
 				    FALSE);
 
 	g_object_set (thumbview->priv->pixbuf_cell,
+#if !GTK_CHECK_VERSION (3, 16, 0)
 	              "follow-state", FALSE,
+#endif
 	              "height", 100,
 	              "width", 115,
 	              "yalign", 0.5,

--- a/src/eom-window.c
+++ b/src/eom-window.c
@@ -4458,7 +4458,7 @@ eom_window_construct_ui (EomWindow *window)
 
 	gtk_box_pack_start (GTK_BOX (priv->layout), hpaned, TRUE, TRUE, 0);
 
-	priv->thumbview = eom_thumb_view_new ();
+	priv->thumbview = g_object_ref (eom_thumb_view_new ());
 
 	/* giving shape to the view */
 	gtk_icon_view_set_margin (GTK_ICON_VIEW (priv->thumbview), 4);
@@ -4585,6 +4585,16 @@ eom_window_dispose (GObject *object)
 	if (priv->page_setup != NULL) {
 		g_object_unref (priv->page_setup);
 		priv->page_setup = NULL;
+	}
+
+	if (priv->thumbview)
+	{
+		/* Disconnect so we don't get any unwanted callbacks
+		 * when the thumb view is disposed. */
+		g_signal_handlers_disconnect_by_func (priv->thumbview,
+		                 G_CALLBACK (handle_image_selection_changed_cb),
+		                 window);
+		g_clear_object (&priv->thumbview);
 	}
 
 	eom_plugin_engine_garbage_collect ();


### PR DESCRIPTION
to avoid:
(eom:22247): EOM-CRITICAL **: eom_list_store_length: assertion 'EOM_IS_LIST_STORE (store)' failed

(eom:14608): GLib-GObject-WARNING **: The property GtkCellRendererPixbuf:follow-state is deprecated and shouldn't be used anymore. It will be removed in a future version.