### PR TITLE
GTK3: toolbar-editor: Fix a crash when dropping an item to the toolbar

### DIFF
--- a/cut-n-paste/toolbar-editor/egg-editable-toolbar.c
+++ b/cut-n-paste/toolbar-editor/egg-editable-toolbar.c
@@ -549,8 +549,13 @@ action_sensitive_cb (GtkAction   *action,
                      GParamSpec  *pspec,
                      GtkToolItem *item)
 {
-  EggEditableToolbar *etoolbar = EGG_EDITABLE_TOOLBAR
-    (gtk_widget_get_ancestor (GTK_WIDGET (item), EGG_TYPE_EDITABLE_TOOLBAR));
+  EggEditableToolbar *etoolbar;
+  GtkWidget *ancestor = gtk_widget_get_ancestor (GTK_WIDGET (item), EGG_TYPE_EDITABLE_TOOLBAR);
+
+  if (!ancestor)
+    return;
+
+  etoolbar = EGG_EDITABLE_TOOLBAR (ancestor);
 
   if (etoolbar->priv->edit_mode > 0)
     {


### PR DESCRIPTION
action_sensitive_cb can be called with the dnd tool item
when it doesn't have an ancestor.

taken from:
https://git.gnome.org/browse/eog/commit/?id=c754959