### PR TITLE
mispositioned brackets in update_scrollbar_values

### DIFF
--- a/src/eom-scroll-view.c
+++ b/src/eom-scroll-view.c
@@ -351,6 +351,7 @@ update_scrollbar_values (EomScrollView *view)
 		g_signal_handlers_unblock_matched (
 			priv->hadj, G_SIGNAL_MATCH_DATA,
 			0, 0, NULL, NULL, view);
+	}
 
 	if (gtk_widget_get_visible (GTK_WIDGET (priv->vbar))) {
 		page_size = MIN (scaled_height, allocation.height);
@@ -372,7 +373,6 @@ update_scrollbar_values (EomScrollView *view)
 		g_signal_handlers_unblock_matched (
 			priv->vadj, G_SIGNAL_MATCH_DATA,
 			0, 0, NULL, NULL, view);
-		}
 	}
 }
 


### PR DESCRIPTION
make tall images scroll bad after zoom-ins until hbar appears

Just try to zoom in some tall but narrow image (when vbar is visible but no hbar yet). The vbar will be freezed until hbar appears: this makes impossible to see all the image moving it by the vbar or the mouse.