### PR TITLE
Fix formatting for manpage: eom -f and -s examples

### DIFF
--- a/man/eom.1
+++ b/man/eom.1
@@ -50,7 +50,7 @@ Open the referenced file in fullscreen mode.
 .PP
 \fBeom \-s /usr/share/eom/icons/hicolor/scalable/actions\fR
 .RS 4
-Open the images in the reference directory in slideshow mode.
+Open the images in the referenced directory in slideshow mode.
 .SH "BUGS"
 .SS Should you encounter any bugs, they may be reported at: 
 http://github.com/mate-desktop/eom/issues

--- a/man/eom.1
+++ b/man/eom.1
@@ -45,12 +45,12 @@ This program also accepts the standard GTK options.
 .SH "EXAMPLES"
 \fBeom \-f http://mate-desktop.org/assets/img/icons/mate.png\fR
 .RS 4
-Open http://mate-desktop.org/assets/img/icons/mate.png in fullscreen mode.
+Open the referenced file in fullscreen mode.
 .RE
 .PP
 \fBeom \-s /usr/share/eom/icons/hicolor/scalable/actions\fR
 .RS 4
-Open the images in the directory "/usr/share/eom/icons/hicolor/scalable/actions" in slideshow mode.
+Open the images in the reference directory in slideshow mode.
 .SH "BUGS"
 .SS Should you encounter any bugs, they may be reported at: 
 http://github.com/mate-desktop/eom/issues


### PR DESCRIPTION
Rewrote the information in the manpage for the examples "eom -f" and "eom -s", to make it clearer and eliminate the stretching of text across the page.