### PR TITLE
Fix the zoom and scroll performance. Closes #105.

### DIFF
--- a/src/eom-scroll-view.c
+++ b/src/eom-scroll-view.c
@@ -1355,9 +1355,10 @@ display_expose_event (GtkWidget *widget, GdkEventExpose *event, gpointer data)
 		cairo_scale (cr, priv->zoom, priv->zoom);
 		cairo_set_source_surface (cr, priv->surface, xofs/priv->zoom, yofs/priv->zoom);
 		cairo_pattern_set_extend (cairo_get_source (cr), CAIRO_EXTEND_PAD);
-		if ((is_zoomed_in (view) && priv->interp_type_in == CAIRO_FILTER_NEAREST) ||
-		    (is_zoomed_out (view) && priv->interp_type_out == CAIRO_FILTER_NEAREST))
-			cairo_pattern_set_filter (cairo_get_source (cr), CAIRO_FILTER_NEAREST);
+		if (is_zoomed_in (view))
+			cairo_pattern_set_filter (cairo_get_source (cr), priv->interp_type_in);
+		else if (is_zoomed_out (view))
+			cairo_pattern_set_filter (cairo_get_source (cr), priv->interp_type_out);
 		cairo_paint (cr);
 	}
 


### PR DESCRIPTION
Adapted from https://git.gnome.org/browse/eog/commit/id=3d1859e321b9dea27e49bab9626044f3f5835420

I've tested using https://www.nasa.gov/sites/default/files/thumbnails/image/crop_p_color2_enhanced_release.png and eom no longer crashes and zoom and scroll performance is restored.