### PR TITLE
gtk 3.22: avoid deprecated gdk_screen_get_monitor... functions:

### DIFF
--- a/src/eom-window.c
+++ b/src/eom-window.c
@@ -1168,6 +1168,9 @@ eom_window_obtain_desired_size (EomImage  *image,
 				EomWindow *window)
 {
 	GdkScreen *screen;
+#if GTK_CHECK_VERSION (3, 22, 0)
+	GdkDisplay *display;
+#endif
 	GdkRectangle monitor;
 	GtkAllocation allocation;
 	gint final_width, final_height;
@@ -1199,11 +1202,19 @@ eom_window_obtain_desired_size (EomImage  *image,
 	window_height = allocation.height;
 
 	screen = gtk_window_get_screen (GTK_WINDOW (window));
+#if GTK_CHECK_VERSION (3, 22, 0)
+	display = gdk_screen_get_display (screen);
+
+	gdk_monitor_get_geometry (gdk_display_get_monitor_at_window (display,
+								     gtk_widget_get_window (GTK_WIDGET (window))),
+				  &monitor);
+#else
 
 	gdk_screen_get_monitor_geometry (screen,
 			gdk_screen_get_monitor_at_window (screen,
 				gtk_widget_get_window (GTK_WIDGET (window))),
 			&monitor);
+#endif
 
 	screen_width  = monitor.width;
 	screen_height = monitor.height;
@@ -1643,18 +1654,28 @@ eom_window_update_fullscreen_popup (EomWindow *window)
 	GtkWidget *popup = window->priv->fullscreen_popup;
 	GdkRectangle screen_rect;
 	GdkScreen *screen;
+#if GTK_CHECK_VERSION (3, 22, 0)
+	GdkDisplay *display;
+#endif
 
 	g_return_if_fail (popup != NULL);
 
 	if (gtk_widget_get_window (GTK_WIDGET (window)) == NULL) return;
 
 	screen = gtk_widget_get_screen (GTK_WIDGET (window));
+#if GTK_CHECK_VERSION (3, 22, 0)
+	display = gdk_screen_get_display (screen);
 
+	gdk_monitor_get_geometry (gdk_display_get_monitor_at_window (display,
+								     gtk_widget_get_window (GTK_WIDGET (window))),
+				  &screen_rect);
+#else
 	gdk_screen_get_monitor_geometry (screen,
 			gdk_screen_get_monitor_at_window
                         (screen,
                          gtk_widget_get_window (GTK_WIDGET (window))),
                          &screen_rect);
+#endif
 
 	gtk_widget_set_size_request (popup,
 				     screen_rect.width,


### PR DESCRIPTION
avoid deprecated:

gdk_screen_get_monitor_geometry
gdk_screen_get_monitor_at_window