### PR TITLE
toolbar: add missing popup menu for launching toolbar editor

### DIFF
--- a/data/eom-ui.xml
+++ b/data/eom-ui.xml
@@ -141,6 +141,10 @@
     <menuitem action="ImageSetAsWallpaper"/>
   </popup>
 
+  <popup name="ToolbarPopup" action="ToolbarPopupAction">
+    <menuitem action="EditToolbar"/>
+  </popup>
+
   <accelerator name="ControlEqualAccel" action="ControlEqual"/>
   <accelerator name="ControlKPAddAccel" action="ControlKpAdd"/>
   <accelerator name="ControlKPSubAccel" action="ControlKpSub"/>

--- a/src/eom-window.c
+++ b/src/eom-window.c
@@ -4322,6 +4322,7 @@ eom_window_construct_ui (EomWindow *window)
 	priv->toolbar = GTK_WIDGET
 		(g_object_new (EGG_TYPE_EDITABLE_TOOLBAR,
 			       "ui-manager", priv->ui_mgr,
+			       "popup-path", "/ToolbarPopup",
 			       "model", eom_application_get_toolbars_model (EOM_APP),
 			       NULL));
 


### PR DESCRIPTION
Should be working with both keyboard and mouse.