### PR TITLE
some fixes for properties dialog

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -22,7 +22,6 @@ gsettings_SCHEMAS = org.mate.eom.gschema.xml
 
 uidir = $(pkgdatadir)
 ui_DATA = \
-	eom-image-properties-dialog.ui \
 	eom-multiple-save-as-dialog.ui \
 	eom-preferences-dialog.ui \
 	eom-toolbar.xml
@@ -33,6 +32,7 @@ pkgconfig_DATA = eom.pc
 EXTRA_DIST = \
 	$(ui_DATA) \
 	eom.css			\
+	eom-image-properties-dialog.ui	\
 	eom-ui.xml		\
 	metadata-sidebar.ui	\
 	$(DESKTOP_IN_FILES) \

--- a/data/eom-image-properties-dialog.ui
+++ b/data/eom-image-properties-dialog.ui
@@ -2,7 +2,7 @@
 <!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.22"/>
-  <object class="GtkDialog" id="eom_image_properties_dialog">
+  <template class="EomPropertiesDialog" parent="GtkDialog">
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Image Properties</property>
@@ -144,6 +144,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="border_width">5</property>
+            <signal name="switch-page" handler="eom_properties_dialog_page_switch" object="EomPropertiesDialog" swapped="no"/>
             <child>
               <object class="GtkBox" id="general_box">
                 <property name="visible">True</property>
@@ -390,6 +391,7 @@
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
+                            <signal name="clicked" handler="pd_folder_button_clicked_cb" object="EomPropertiesDialog" swapped="no"/>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -940,6 +942,7 @@
                         <attributes>
                           <attribute name="weight" value="bold"/>
                         </attributes>
+                        <signal name="notify::expanded" handler="pd_exif_details_activated_cb" object="EomPropertiesDialog" after="yes" swapped="no"/>
                       </object>
                     </child>
                   </object>
@@ -1008,5 +1011,5 @@
     <style>
       <class name="eom-image-properties-dialog"/>
     </style>
-  </object>
+  </template>
 </interface>

--- a/src/eom-metadata-sidebar.c
+++ b/src/eom-metadata-sidebar.c
@@ -304,7 +304,7 @@ static void
 _details_button_clicked_cb (GtkButton *button, gpointer user_data)
 {
 	EomMetadataSidebarPrivate *priv = EOM_METADATA_SIDEBAR(user_data)->priv;
-	EomDialog *dlg;
+	GtkWidget *dlg;
 
 	g_return_if_fail (priv->parent_window != NULL);
 
@@ -313,7 +313,7 @@ _details_button_clicked_cb (GtkButton *button, gpointer user_data)
 	g_return_if_fail (dlg != NULL);
 	eom_properties_dialog_set_page (EOM_PROPERTIES_DIALOG (dlg),
 					EOM_PROPERTIES_DIALOG_PAGE_DETAILS);
-	eom_dialog_show (dlg);
+	gtk_widget_show (dlg);
 }
 #endif /* HAVE_METADATA */
 

--- a/src/eom-properties-dialog.c
+++ b/src/eom-properties-dialog.c
@@ -105,7 +105,7 @@ struct _EomPropertiesDialogPrivate {
 	gboolean        netbook_mode;
 };
 
-G_DEFINE_TYPE_WITH_PRIVATE (EomPropertiesDialog, eom_properties_dialog, EOM_TYPE_DIALOG);
+G_DEFINE_TYPE_WITH_PRIVATE (EomPropertiesDialog, eom_properties_dialog, GTK_TYPE_DIALOG);
 
 static void
 pd_update_general_tab (EomPropertiesDialog *prop_dlg,
@@ -403,19 +403,11 @@ pd_exif_details_activated_cb (GtkExpander *expander,
 #endif
 
 static void
-pd_close_button_clicked_cb (GtkButton *button,
-			    gpointer   user_data)
-{
-	eom_dialog_hide (EOM_DIALOG (user_data));
-}
-
-static void
 pd_folder_button_clicked_cb (GtkButton *button, gpointer data)
 {
 	EomPropertiesDialogPrivate *priv = EOM_PROPERTIES_DIALOG (data)->priv;
 	GdkScreen *screen;
 	guint32 timestamp;
-
 
 	if (!priv->folder_button_uri)
 		return;
@@ -432,21 +424,8 @@ eom_properties_dialog_page_switch (GtkNotebook     *notebook,
 				   guint            page_index,
 				   EomPropertiesDialog *prop_dlg)
 {
-
 	if (prop_dlg->priv->update_page)
 		prop_dlg->priv->current_page = page_index;
-
-	return TRUE;
-}
-
-static gint
-eom_properties_dialog_delete (GtkWidget   *widget,
-			      GdkEventAny *event,
-			      gpointer     user_data)
-{
-	g_return_val_if_fail (EOM_IS_PROPERTIES_DIALOG (user_data), FALSE);
-
-	eom_dialog_hide (EOM_DIALOG (user_data));
 
 	return TRUE;
 }
@@ -563,9 +542,9 @@ eom_properties_dialog_dispose (GObject *object)
 }
 
 static void
-eom_properties_dialog_class_init (EomPropertiesDialogClass *class)
+eom_properties_dialog_class_init (EomPropertiesDialogClass *klass)
 {
-	GObjectClass *g_object_class = (GObjectClass *) class;
+	GObjectClass *g_object_class = (GObjectClass *) klass;
 
 	g_object_class->dispose = eom_properties_dialog_dispose;
 	g_object_class->set_property = eom_properties_dialog_set_property;
@@ -589,13 +568,125 @@ eom_properties_dialog_class_init (EomPropertiesDialogClass *class)
 							      FALSE,
 							      G_PARAM_READWRITE |
 							      G_PARAM_STATIC_STRINGS));
+
+	gchar* data;
+	gsize data_size;
+	g_file_get_contents(g_build_filename (EOM_DATA_DIR, "eom-image-properties-dialog.ui", NULL), &data, &data_size, NULL);
+	GBytes *bytes = g_bytes_new_static(data, data_size);
+	gtk_widget_class_set_template((GtkWidgetClass *) klass, bytes);
+
+	GtkWidgetClass *wklass = (GtkWidgetClass*) klass;
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     notebook);
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     previous_button);
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     next_button);
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     close_button);
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     thumbnail_image);
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     general_box);
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     name_label);
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     width_label);
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     height_label);
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     type_label);
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     bytes_label);
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     folder_button);
+
+#if HAVE_EXIF
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     exif_aperture_label);
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     exif_exposure_label);
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     exif_focal_label);
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     exif_flash_label);
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     exif_iso_label);
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     exif_metering_label);
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     exif_model_label);
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     exif_date_label);
+#endif
+#if HAVE_EXEMPI
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     xmp_location_label);
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     xmp_description_label);
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     xmp_keywords_label);
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     xmp_creator_label);
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     xmp_rights_label);
+#else
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     xmp_box);
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     xmp_box_label);
+#endif
+#ifdef HAVE_METADATA
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     metadata_box);
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     metadata_details_expander);
+	gtk_widget_class_bind_template_child_private(wklass,
+						     EomPropertiesDialog,
+						     metadata_details_box);
+
+	gtk_widget_class_bind_template_callback(wklass,
+						pd_exif_details_activated_cb);
+#endif
+	gtk_widget_class_bind_template_callback(wklass,
+						eom_properties_dialog_page_switch);
+	gtk_widget_class_bind_template_callback(wklass,
+						pd_folder_button_clicked_cb);
 }
 
 static void
 eom_properties_dialog_init (EomPropertiesDialog *prop_dlg)
 {
 	EomPropertiesDialogPrivate *priv;
-	GtkWidget *dlg;
 #ifndef HAVE_EXEMPI
 	GtkWidget *xmp_box, *xmp_box_label;
 #endif
@@ -609,70 +700,17 @@ eom_properties_dialog_init (EomPropertiesDialog *prop_dlg)
 
 	priv->update_page = FALSE;
 
-	eom_dialog_construct (EOM_DIALOG (prop_dlg),
-			      "eom-image-properties-dialog.ui",
-			      "eom_image_properties_dialog");
+	gtk_widget_init_template (GTK_WIDGET (prop_dlg));
 
-	eom_dialog_get_controls (EOM_DIALOG (prop_dlg),
-			         "eom_image_properties_dialog", &dlg,
-			         "notebook", &priv->notebook,
-			         "previous_button", &priv->previous_button,
-			         "next_button", &priv->next_button,
-			         "close_button", &priv->close_button,
-			         "thumbnail_image", &priv->thumbnail_image,
-			         "general_box", &priv->general_box,
-			         "name_label", &priv->name_label,
-			         "width_label", &priv->width_label,
-			         "height_label", &priv->height_label,
-			         "type_label", &priv->type_label,
-			         "bytes_label", &priv->bytes_label,
-			         "folder_button", &priv->folder_button,
-#ifdef HAVE_EXIF
-			         "exif_aperture_label", &priv->exif_aperture_label,
-			         "exif_exposure_label", &priv->exif_exposure_label,
-			         "exif_focal_label", &priv->exif_focal_label,
-			         "exif_flash_label", &priv->exif_flash_label,
-			         "exif_iso_label", &priv->exif_iso_label,
-			         "exif_metering_label", &priv->exif_metering_label,
-			         "exif_model_label", &priv->exif_model_label,
-			         "exif_date_label", &priv->exif_date_label,
-#endif
-#ifdef HAVE_EXEMPI
-				 "xmp_location_label", &priv->xmp_location_label,
-				 "xmp_description_label", &priv->xmp_description_label,
-				 "xmp_keywords_label", &priv->xmp_keywords_label,
-				 "xmp_creator_label", &priv->xmp_creator_label,
-				 "xmp_rights_label", &priv->xmp_rights_label,
-#else
-				 "xmp_box", &xmp_box,
-				 "xmp_box_label", &xmp_box_label,
-#endif
-#ifdef HAVE_METADATA
-				 "metadata_box", &priv->metadata_box,
-				 "metadata_details_expander", &priv->metadata_details_expander,
-				 "metadata_details_box", &priv->metadata_details_box,
-#endif
-			         NULL);
+	g_signal_connect (prop_dlg,
+	                  "delete-event",
+	                 G_CALLBACK (gtk_widget_hide_on_delete),
+	                 prop_dlg);
 
-	g_signal_connect (dlg,
-			  "delete-event",
-			  G_CALLBACK (eom_properties_dialog_delete),
-			  prop_dlg);
-
-	g_signal_connect (priv->notebook,
-			  "switch-page",
-			  G_CALLBACK (eom_properties_dialog_page_switch),
-			  prop_dlg);
-
-	g_signal_connect (priv->close_button,
-			  "clicked",
-			  G_CALLBACK (pd_close_button_clicked_cb),
-			  prop_dlg);
-
-	g_signal_connect (priv->folder_button,
-			  "clicked",
-			  G_CALLBACK (pd_folder_button_clicked_cb),
-			  prop_dlg);
+	g_signal_connect_swapped (priv->close_button,
+	                          "clicked",
+	                          G_CALLBACK (gtk_widget_hide_on_delete),
+	                          prop_dlg);
 
 	gtk_widget_set_size_request (priv->thumbnail_image, 100, 100);
 
@@ -705,11 +743,6 @@ eom_properties_dialog_init (EomPropertiesDialog *prop_dlg)
 				   sw);
 	}
 
-	g_signal_connect_after (G_OBJECT (priv->metadata_details_expander),
-			        "notify::expanded",
-			  	G_CALLBACK (pd_exif_details_activated_cb),
-			  	dlg);
-
 #ifndef HAVE_EXEMPI
 	gtk_widget_hide (xmp_box);
 	gtk_widget_hide (xmp_box_label);
@@ -737,7 +770,7 @@ eom_properties_dialog_init (EomPropertiesDialog *prop_dlg)
  * Returns: (transfer full) (type EomPropertiesDialog): a new #EomPropertiesDialog
  **/
 
-GObject *
+GtkWidget *
 eom_properties_dialog_new (GtkWindow    *parent,
 			   EomThumbView *thumbview,
 			   GtkAction    *next_image_action,
@@ -751,15 +784,18 @@ eom_properties_dialog_new (GtkWindow    *parent,
 	g_return_val_if_fail (GTK_IS_ACTION (previous_image_action), NULL);
 
 	prop_dlg = g_object_new (EOM_TYPE_PROPERTIES_DIALOG,
-				 "parent-window", parent,
-			     	 "thumbview", thumbview,
-			     	 NULL);
+	                         "thumbview", thumbview,
+	                         NULL);
+
+	if (parent) {
+		gtk_window_set_transient_for (GTK_WINDOW (prop_dlg), parent);
+	}
 
 	gtk_activatable_set_related_action (GTK_ACTIVATABLE (EOM_PROPERTIES_DIALOG (prop_dlg)->priv->next_button), next_image_action);
 
 	gtk_activatable_set_related_action (GTK_ACTIVATABLE (EOM_PROPERTIES_DIALOG (prop_dlg)->priv->previous_button), previous_image_action);
 
-	return prop_dlg;
+	return GTK_WIDGET (prop_dlg);
 }
 
 void

--- a/src/eom-properties-dialog.c
+++ b/src/eom-properties-dialog.c
@@ -77,8 +77,6 @@ struct _EomPropertiesDialogPrivate {
 	GtkWidget      *bytes_label;
 	GtkWidget      *folder_button;
 	gchar          *folder_button_uri;
-	GtkWidget      *created_label;
-	GtkWidget      *modified_label;
 #ifdef HAVE_EXIF
 	GtkWidget      *exif_aperture_label;
 	GtkWidget      *exif_exposure_label;
@@ -629,8 +627,6 @@ eom_properties_dialog_init (EomPropertiesDialog *prop_dlg)
 			         "type_label", &priv->type_label,
 			         "bytes_label", &priv->bytes_label,
 			         "folder_button", &priv->folder_button,
-			         "created_label", &priv->created_label,
-			         "modified_label", &priv->modified_label,
 #ifdef HAVE_EXIF
 			         "exif_aperture_label", &priv->exif_aperture_label,
 			         "exif_exposure_label", &priv->exif_exposure_label,

--- a/src/eom-properties-dialog.c
+++ b/src/eom-properties-dialog.c
@@ -406,16 +406,16 @@ static void
 pd_folder_button_clicked_cb (GtkButton *button, gpointer data)
 {
 	EomPropertiesDialogPrivate *priv = EOM_PROPERTIES_DIALOG (data)->priv;
-	GdkScreen *screen;
+	GtkWindow *window;
 	guint32 timestamp;
 
 	if (!priv->folder_button_uri)
 		return;
 	
-	screen = gtk_widget_get_screen (GTK_WIDGET (button));
 	timestamp = gtk_get_current_event_time ();
 
-	gtk_show_uri (screen, priv->folder_button_uri, timestamp, NULL);
+	window = GTK_WINDOW (data);
+	gtk_show_uri_on_window (window, priv->folder_button_uri, timestamp, NULL);
 }
 
 static gboolean

--- a/src/eom-properties-dialog.c
+++ b/src/eom-properties-dialog.c
@@ -569,13 +569,11 @@ eom_properties_dialog_class_init (EomPropertiesDialogClass *klass)
 							      G_PARAM_READWRITE |
 							      G_PARAM_STATIC_STRINGS));
 
-	gchar* data;
-	gsize data_size;
-	g_file_get_contents(g_build_filename (EOM_DATA_DIR, "eom-image-properties-dialog.ui", NULL), &data, &data_size, NULL);
-	GBytes *bytes = g_bytes_new_static(data, data_size);
-	gtk_widget_class_set_template((GtkWidgetClass *) klass, bytes);
-
 	GtkWidgetClass *wklass = (GtkWidgetClass*) klass;
+
+	gtk_widget_class_set_template_from_resource (wklass,
+	                                             "/org/mate/eom/ui/eom-image-properties-dialog.ui");
+
 	gtk_widget_class_bind_template_child_private(wklass,
 						     EomPropertiesDialog,
 						     notebook);

--- a/src/eom-properties-dialog.h
+++ b/src/eom-properties-dialog.h
@@ -22,7 +22,6 @@
 #ifndef __EOM_PROPERTIES_DIALOG_H__
 #define __EOM_PROPERTIES_DIALOG_H__
 
-#include "eom-dialog.h"
 #include "eom-image.h"
 #include "eom-thumb-view.h"
 
@@ -51,21 +50,21 @@ typedef enum {
 } EomPropertiesDialogPage;
 
 struct _EomPropertiesDialog {
-	EomDialog dialog;
+	GtkDialog dialog;
 
 	EomPropertiesDialogPrivate *priv;
 };
 
 struct _EomPropertiesDialogClass {
-	EomDialogClass parent_class;
+	GtkDialogClass parent_class;
 };
 
 GType	    eom_properties_dialog_get_type	(void) G_GNUC_CONST;
 
-GObject    *eom_properties_dialog_new	  	(GtkWindow               *parent,
-                                                 EomThumbView            *thumbview,
-						 GtkAction               *next_image_action,
-						 GtkAction               *previous_image_action);
+GtkWidget   *eom_properties_dialog_new	  	(GtkWindow               *parent,
+                                             EomThumbView            *thumbview,
+                                             GtkAction               *next_image_action,
+                                             GtkAction               *previous_image_action);
 
 void	    eom_properties_dialog_update  	(EomPropertiesDialog     *prop,
 						 EomImage                *image);

--- a/src/eom-window.c
+++ b/src/eom-window.c
@@ -144,7 +144,7 @@ struct _EomWindowPrivate {
 	GtkWidget           *nav;
 	GtkWidget           *message_area;
 	GtkWidget           *toolbar;
-	GObject             *properties_dlg;
+	GtkWidget           *properties_dlg;
 
 	GtkActionGroup      *actions_window;
 	GtkActionGroup      *actions_image;
@@ -3044,7 +3044,7 @@ eom_window_cmd_print (GtkAction *action, gpointer user_data)
  * Returns: (transfer none): a #GtkDialog.
  */
 
-EomDialog*
+GtkWidget*
 eom_window_get_properties_dialog (EomWindow *window)
 {
 	EomWindowPrivate *priv;
@@ -3077,7 +3077,7 @@ eom_window_get_properties_dialog (EomWindow *window)
 				 G_SETTINGS_BIND_GET);
 	}
 
-	return EOM_DIALOG (priv->properties_dlg);
+	return priv->properties_dlg;
 }
 
 static void
@@ -3085,12 +3085,12 @@ eom_window_cmd_properties (GtkAction *action, gpointer user_data)
 {
 	EomWindow *window = EOM_WINDOW (user_data);
 	EomWindowPrivate *priv;
-	EomDialog *dialog;
+	GtkWidget *dialog;
 
 	priv = window->priv;
 
 	dialog = eom_window_get_properties_dialog (window);
-	eom_dialog_show (dialog);
+	gtk_widget_show (dialog);
 }
 
 static void

--- a/src/eom-window.h
+++ b/src/eom-window.h
@@ -125,7 +125,7 @@ void          eom_window_open_file_list	(EomWindow       *window,
 gboolean      eom_window_is_empty 	(EomWindow       *window);
 
 void          eom_window_reload_image (EomWindow *window);
-EomDialog    *eom_window_get_properties_dialog (EomWindow *window);
+GtkWidget    *eom_window_get_properties_dialog (EomWindow *window);
 G_END_DECLS
 
 #endif

--- a/src/eom.gresource.xml
+++ b/src/eom.gresource.xml
@@ -2,6 +2,7 @@
 <gresources>
   <gresource prefix="/org/mate/eom/ui">
     <file>eom.css</file>
+    <file compressed="true" preprocess="xml-stripblanks">eom-image-properties-dialog.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">eom-ui.xml</file>
     <file compressed="true" preprocess="xml-stripblanks">metadata-sidebar.ui</file>
   </gresource>


### PR DESCRIPTION
`EomPropertiesDialog: Convert to GtkBuilder template` fixes
- known runtime warning `GtkDialog mapped without a transient parent. This is discouraged.`
- makes it possible to fix deprecated `gtk_show_uri`

Please test.