### PR TITLE
Performance improvement on open

### DIFF
--- a/src/eom-image.c
+++ b/src/eom-image.c
@@ -315,13 +315,14 @@ eom_image_init (EomImage *img)
 }
 
 EomImage *
-eom_image_new_file (GFile *file)
+eom_image_new_file (GFile *file, const gchar *caption)
 {
 	EomImage *img;
 
 	img = EOM_IMAGE (g_object_new (EOM_TYPE_IMAGE, NULL));
 
 	img->priv->file = g_object_ref (file);
+	img->priv->caption = g_strdup (caption);
 
 	return img;
 }

--- a/src/eom-image.c
+++ b/src/eom-image.c
@@ -315,18 +315,6 @@ eom_image_init (EomImage *img)
 }
 
 EomImage *
-eom_image_new (const char *txt_uri)
-{
-	EomImage *img;
-
-	img = EOM_IMAGE (g_object_new (EOM_TYPE_IMAGE, NULL));
-
-	img->priv->file = g_file_new_for_uri (txt_uri);
-
-	return img;
-}
-
-EomImage *
 eom_image_new_file (GFile *file)
 {
 	EomImage *img;

--- a/src/eom-image.h
+++ b/src/eom-image.h
@@ -121,8 +121,6 @@ GType	          eom_image_get_type	             (void) G_GNUC_CONST;
 
 GQuark            eom_image_error_quark              (void);
 
-EomImage         *eom_image_new                      (const char *txt_uri);
-
 EomImage         *eom_image_new_file                 (GFile *file);
 
 gboolean          eom_image_load                     (EomImage   *img,

--- a/src/eom-image.h
+++ b/src/eom-image.h
@@ -121,7 +121,7 @@ GType	          eom_image_get_type	             (void) G_GNUC_CONST;
 
 GQuark            eom_image_error_quark              (void);
 
-EomImage         *eom_image_new_file                 (GFile *file);
+EomImage         *eom_image_new_file                 (GFile *file, const gchar *caption);
 
 gboolean          eom_image_load                     (EomImage   *img,
 					              EomImageData data2read,

--- a/src/eom-list-store.c
+++ b/src/eom-list-store.c
@@ -352,13 +352,14 @@ eom_list_store_append_image (EomListStore *store, EomImage *image)
 
 static void
 eom_list_store_append_image_from_file (EomListStore *store,
-				       GFile *file)
+				       GFile *file,
+				       const gchar *caption)
 {
 	EomImage *image;
 
 	g_return_if_fail (EOM_IS_LIST_STORE (store));
 
-	image = eom_image_new_file (file);
+	image = eom_image_new_file (file, caption);
 
 	eom_list_store_append_image (store, image);
 }
@@ -378,7 +379,8 @@ file_monitor_changed_cb (GFileMonitor *monitor,
 	switch (event) {
 	case G_FILE_MONITOR_EVENT_CHANGES_DONE_HINT:
 		file_info = g_file_query_info (file,
-					       G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE,
+					       G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE ","
+					       G_FILE_ATTRIBUTE_STANDARD_DISPLAY_NAME,
 					       0, NULL, NULL);
 		if (file_info == NULL) {
 			break;
@@ -398,7 +400,10 @@ file_monitor_changed_cb (GFileMonitor *monitor,
 			}
 		} else {
 			if (eom_image_is_supported_mime_type (mimetype)) {
-				eom_list_store_append_image_from_file (store, file);
+				const gchar *caption;
+
+				caption = g_file_info_get_display_name (file_info);
+				eom_list_store_append_image_from_file (store, file, caption);
 			}
 		}
 		g_object_unref (file_info);
@@ -417,7 +422,8 @@ file_monitor_changed_cb (GFileMonitor *monitor,
 	case G_FILE_MONITOR_EVENT_CREATED:
 		if (!is_file_in_list_store_file (store, file, NULL)) {
 			file_info = g_file_query_info (file,
-						       G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE,
+						       G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE ","
+						       G_FILE_ATTRIBUTE_STANDARD_DISPLAY_NAME,
 						       0, NULL, NULL);
 			if (file_info == NULL) {
 				break;
@@ -425,7 +431,10 @@ file_monitor_changed_cb (GFileMonitor *monitor,
 			mimetype = g_file_info_get_content_type (file_info);
 
 			if (eom_image_is_supported_mime_type (mimetype)) {
-				eom_list_store_append_image_from_file (store, file);
+				const gchar *caption;
+
+				caption = g_file_info_get_display_name (file_info);
+				eom_list_store_append_image_from_file (store, file, caption);
 			}
 			g_object_unref (file_info);
 		}
@@ -473,8 +482,11 @@ directory_visit (GFile *directory,
 	}
 
 	if (load_uri) {
+		const gchar *caption;
+
 		child = g_file_get_child (directory, name);
-		eom_list_store_append_image_from_file (store, child);
+		caption = g_file_info_get_display_name (children_info);
+		eom_list_store_append_image_from_file (store, child, caption);
 	}
 }
 
@@ -503,6 +515,7 @@ eom_list_store_append_directory (EomListStore *store,
 
 	file_enumerator = g_file_enumerate_children (file,
 						     G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE ","
+						     G_FILE_ATTRIBUTE_STANDARD_DISPLAY_NAME ","
 						     G_FILE_ATTRIBUTE_STANDARD_NAME,
 						     0, NULL, NULL);
 	file_info = g_file_enumerator_next_file (file_enumerator, NULL, NULL);
@@ -549,14 +562,18 @@ eom_list_store_add_files (EomListStore *store, GList *file_list)
 
 	for (it = file_list; it != NULL; it = it->next) {
 		GFile *file = (GFile *) it->data;
+		gchar *caption = NULL;
 
 		file_info = g_file_query_info (file,
 					       G_FILE_ATTRIBUTE_STANDARD_TYPE","
-					       G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE,
+					       G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE","
+					       G_FILE_ATTRIBUTE_STANDARD_DISPLAY_NAME,
 					       0, NULL, NULL);
 		if (file_info == NULL) {
 			continue;
 		}
+
+		caption = g_strdup (g_file_info_get_display_name (file_info));
 		file_type = g_file_info_get_file_type (file_info);
 
 		/* Workaround for gvfs backends that don't set the GFileType. */
@@ -597,16 +614,18 @@ eom_list_store_add_files (EomListStore *store, GList *file_list)
 				if (!is_file_in_list_store_file (store,
 								 initial_file,
 								 &iter)) {
-					eom_list_store_append_image_from_file (store, initial_file);
+					eom_list_store_append_image_from_file (store, initial_file, caption);
 				}
 			} else {
-				eom_list_store_append_image_from_file (store, initial_file);
+				eom_list_store_append_image_from_file (store, initial_file, caption);
 			}
 			g_object_unref (file);
 		} else if (file_type == G_FILE_TYPE_REGULAR &&
 			   g_list_length (file_list) > 1) {
-			eom_list_store_append_image_from_file (store, file);
+			eom_list_store_append_image_from_file (store, file, caption);
 		}
+
+		g_free (caption);
 	}
 
 	gtk_tree_sortable_set_sort_column_id (GTK_TREE_SORTABLE (store),


### PR DESCRIPTION
This is based on the [GNOME bug](https://bugzilla.gnome.org/show_bug.cgi?id=764139) referenced on #130.

I've backported the patches to EOM, but I personally don't notice any difference when opening a folder with over 10k images: with and without the patch, it takes eom about ~1.6s to load entirely, and `g_file_query_info` got called at most 2 times, so no difference.

Maybe someone with more (or larger) files can notice a difference?