### PR TITLE
Update the appdata XML file

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -9,7 +9,7 @@ desktopdir = $(datadir)/applications
 desktop_DATA = $(DESKTOP_FILES)
 
 @INTLTOOL_XML_RULE@
-appdatadir = $(datadir)/appdata
+appdatadir = $(datadir)/metainfo
 appdata_in_files = eom.appdata.xml.in
 appdata_DATA = $(appdata_in_files:.xml.in=.xml)
 

--- a/data/eom.appdata.xml.in
+++ b/data/eom.appdata.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2014 Ryan Lerch <rlerch@redhat.com> -->
-<application>
+<component type="desktop">
   <id type="desktop">eom.desktop</id>
   <metadata_license>CC0-1.0</metadata_license>
   <_name>Eye of MATE</_name>
@@ -16,4 +16,4 @@
   <screenshots>
     <screenshot type="default">http://mate-desktop.org/gallery/1.8/eom.png</screenshot>
   </screenshots>
-</application>
+</component>

--- a/data/eom.appdata.xml.in
+++ b/data/eom.appdata.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2014 Ryan Lerch <rlerch@redhat.com> -->
 <component type="desktop">
-  <id type="desktop">eom.desktop</id>
+  <id>eom.desktop</id>
   <metadata_license>CC0-1.0</metadata_license>
   <_name>Eye of MATE</_name>
   <_summary>Simple image viewer</_summary>


### PR DESCRIPTION
This changeset aims to fix the issues pointed out in #154.
- Installation directory is changed from `%{datadir}/appdata/` to `%{datadir}/metainfo`.
- The root node is changed from `<application>` to `<component type="desktop">`.