### PR TITLE
Upgrade the manual to docbook 5.0

### DIFF
--- a/help/C/index.docbook
+++ b/help/C/index.docbook
@@ -214,7 +214,7 @@
 		</revdescription> 
       </revision> 
     </revhistory> 
-    <releaseinfo>This manual describes version 1.10.2 of Image Viewer.
+    <releaseinfo>This manual describes version 1.22 of Image Viewer.
     </releaseinfo>
   </info>
 

--- a/help/C/index.docbook
+++ b/help/C/index.docbook
@@ -1,27 +1,21 @@
-<?xml version="1.0"?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN" 
-"http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
-  <!ENTITY legal SYSTEM "legal.xml">
-  <!ENTITY appversion "1.10.2">
-  <!ENTITY manrevision "2.9">
-  <!ENTITY date "July 2015">
-  <!ENTITY app "<application>Image Viewer</application>">
-  <!ENTITY appname "Image Viewer">
-]>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- 
       (Do not remove this comment block.)
   Maintained by the MATE Documentation Project
   http://wiki.mate-desktop.org/dev-doc:doc-team-guide
   Template version: 2.0 beta
   Template last modified Feb 12, 2002
-  
 -->
-<!-- =============Document Header ============================= -->
-<article id="index" lang="en">
+<?db.chunk.max_depth 2?>
+<article xmlns="http://docbook.org/ns/docbook"
+         xmlns:db="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         version="5.0" xml:id="index" xml:lang="en">
 <!-- please do not change the id; for translations, change lang to -->
 <!-- appropriate code -->
-  <articleinfo> 
-    <title>&appname; Manual</title>
+  <info>
+    <title>Image Viewer Manual</title>
 
     <copyright>
       <year>2015</year>
@@ -46,14 +40,7 @@
       <year>2000</year> 
       <holder>The Free Software Foundation</holder> 
     </copyright>	 
-<!-- translators: uncomment this:
 
-  <copyright>
-   <year>2003</year>
-   <holder>ME-THE-TRANSLATOR (Latin translation)</holder>
-  </copyright>
-
-   -->
 <!-- An address can be added to the publisher information.  If a role is 
      not specified, the publisher/author is the same for all versions of the 
      document.  -->
@@ -64,85 +51,85 @@
       <publishername> GNOME Documentation Project </publishername>
     </publisher>
 
-   &legal;
+   <xi:include href="legal.xml"/>
    <!-- This file  contains link to license for the documentation (GNU FDL), and 
         other legal stuff such as "NO WARRANTY" statement. Please do not change 
 	any of this. -->
+
    <authorgroup>
-   <author> 
-	<firstname>MATE Documentation Project</firstname>
-	<surname></surname>
-	<affiliation>
-	  <orgname>MATE Desktop</orgname>
-	</affiliation>
-   </author>
-   <author>
-	<firstname>Jens</firstname> 
-	<surname>Finke</surname> 
-	<affiliation> 
-	  <orgname>GNOME Documentation Project</orgname>
-	</affiliation>
-   </author>
-   <author> 
-	<firstname>Angela</firstname> 
-	<surname>Boyle</surname> 
-	<affiliation> 
-	  <orgname>GNOME Documentation Project</orgname>
-	</affiliation>
-   </author>
-   <author> 
-	<firstname>Stuart</firstname> 
-	<surname>Ellis</surname> 
-	<affiliation> 
-	  <orgname>GNOME Documentation Project</orgname>
-	</affiliation>
-   </author>
-   <author> 
-	<firstname>Sun</firstname> 
-	<surname>GNOME Documentation Team</surname>
-	<affiliation> 
-	  <orgname>Sun Microsystems</orgname>  
-	</affiliation> 
-   </author> 
-   <author> 
-	<firstname>Eliot</firstname> 
-	<surname>Landrum</surname> 
-	<affiliation> 
-	  <orgname>GNOME Documentation Project</orgname>
-	</affiliation> 
-   </author> 
-   <author> 
-	<firstname>Federico</firstname> 
-	<surname>Mena Quintero</surname> 
-	<affiliation> 
-	  <orgname>GNOME Documentation Project</orgname>
-	</affiliation> 
-   </author>	
-<!-- This is appropriate place for other contributors: translators,
-      maintainers,  etc. Commented out by default.
-       <othercredit role="translator">
-	<firstname>Latin</firstname> 
-	<surname>Translator 1</surname> 
-	<affiliation> 
-	  <orgname>Latin Translation Team</orgname> 
-	  <email>translator@gnome.org</email> 
-	</affiliation>
-	<contrib>Latin translation</contrib>
-      </othercredit>
--->
-    </authorgroup>
+       <author>
+           <orgname>MATE Documentation Project</orgname>
+           <affiliation>
+               <orgname>MATE Desktop</orgname>
+           </affiliation>
+       </author>
+       <author>
+           <personname>
+               <firstname>Jens</firstname>
+               <surname>Finke</surname>
+           </personname>
+           <affiliation>
+               <orgname>GNOME Documentation Project</orgname>
+           </affiliation>
+       </author>
+       <author>
+           <personname>
+               <firstname>Angela</firstname>
+               <surname>Boyle</surname>
+           </personname>
+           <affiliation>
+               <orgname>GNOME Documentation Project</orgname>
+           </affiliation>
+       </author>
+       <author>
+           <personname>
+               <firstname>Stuart</firstname>
+               <surname>Ellis</surname>
+           </personname>
+           <affiliation>
+               <orgname>GNOME Documentation Project</orgname>
+           </affiliation>
+       </author>
+       <author>
+           <personname>
+               <firstname>Sun</firstname>
+               <surname>GNOME Documentation Team</surname>
+           </personname>
+           <affiliation>
+               <orgname>Sun Microsystems</orgname>
+           </affiliation>
+       </author>
+       <author>
+           <personname>
+               <firstname>Eliot</firstname>
+               <surname>Landrum</surname>
+           </personname>
+           <affiliation>
+               <orgname>GNOME Documentation Project</orgname>
+           </affiliation>
+       </author>
+       <author>
+           <personname>
+               <firstname>Federico</firstname>
+               <surname>Mena Quintero</surname>
+           </personname>
+           <affiliation>
+               <orgname>GNOME Documentation Project</orgname>
+           </affiliation>
+       </author>	
+   </authorgroup>
  
     <revhistory>
     <revision> 
-		<revnumber>&appname; Manual V&manrevision;</revnumber> 
-		<date>&date;</date> 
+		<revnumber>2.9</revnumber>
+		<date>July 2015</date>
 		<revdescription> 
 	  		<para role="author">MATE Documentation Project</para>
 	  		<para role="publisher">MATE Documentation Project</para>
 		</revdescription> 
     </revision> 
     <revision>
-		<revnumber>Eye of GNOME Manual V2.8</revnumber>
+		<revnumber>2.8</revnumber>
 		<date>February 2007</date>
 		<revdescription>
 		    <para role="author">GNOME Documentation Project</para>
@@ -150,7 +137,7 @@
 		</revdescription>
     </revision>
     <revision>
-		<revnumber>Eye of GNOME Manual V2.7</revnumber>
+		<revnumber>2.7</revnumber>
 		<date>February 2004</date>
 		<revdescription>
 		    <para role="author">Sun GNOME Documentation Team</para>
@@ -158,7 +145,7 @@
 		</revdescription>
     </revision>
     <revision> 
-		<revnumber>Eye of GNOME Manual V2.6</revnumber>
+		<revnumber>2.6</revnumber>
 		<date>November 2003</date> 
 		<revdescription> 
 		    <para role="author">Sun GNOME Documentation Team</para>
@@ -166,7 +153,7 @@
 		</revdescription> 
     </revision>
     <revision> 
-		<revnumber>Eye of GNOME Manual V2.5</revnumber>
+		<revnumber>2.5</revnumber>
 		<date>September 2003</date> 
 		<revdescription> 
 		    <para role="author">Sun GNOME Documentation Team</para>
@@ -174,7 +161,7 @@
 		</revdescription> 
     </revision>
     <revision> 
-		<revnumber>Eye of GNOME Manual V2.4</revnumber>
+		<revnumber>2.4</revnumber>
 		<date>January 2003</date> 
 		<revdescription> 
 		    <para role="author">Sun GNOME Documentation Team</para>
@@ -182,7 +169,7 @@
 		</revdescription> 
     </revision>
     <revision> 
-		<revnumber>Eye of GNOME Manual V2.3</revnumber>
+		<revnumber>2.3</revnumber>
 		<date>October 2002</date> 
 		<revdescription> 
 		    <para role="author">Sun GNOME Documentation Team</para>
@@ -190,7 +177,7 @@
 		</revdescription> 
     </revision>
     <revision> 
-		<revnumber>Eye of GNOME Manual V2.2</revnumber>
+		<revnumber>2.2</revnumber>
 		<date>August 2002</date> 
 		<revdescription> 
 		    <para role="author">Sun GNOME Documentation Team</para>
@@ -198,7 +185,7 @@
 		</revdescription> 
     </revision>
     <revision> 
-		<revnumber>Eye of GNOME Manual V2.1</revnumber>
+		<revnumber>2.1</revnumber>
 		<date>July 2002</date> 
 		<revdescription> 
 		    <para role="author">Sun GNOME Documentation Team</para>
@@ -206,7 +193,7 @@
 		</revdescription> 
     </revision> 
     <revision> 
-		<revnumber>Eye of GNOME Manual V2.0</revnumber>
+		<revnumber>2.0</revnumber>
 		<date>May 2002</date> 
 		<revdescription> 
 		    <para role="author">Sun GNOME Documentation Team</para>
@@ -214,7 +201,7 @@
 		</revdescription> 
     </revision> 
     <revision> 
-		<revnumber>Eye of GNOME User's Guide</revnumber>
+		<revnumber>1.0</revnumber>
 		<date>2000</date> 
 		<revdescription> 
 		    <para role="author">Eliot Landrum
@@ -227,19 +214,9 @@
 		</revdescription> 
       </revision> 
     </revhistory> 
-    <releaseinfo>This manual describes version &appversion; of &appname;.
+    <releaseinfo>This manual describes version 1.10.2 of Image Viewer.
     </releaseinfo>
-    <legalnotice>
-      <title>Feedback</title>
-      <para>To report a bug or make a suggestion regarding the &appname; application or this manual, follow the directions in the <ulink url="help:mate-user-guide/feedback" type="help">MATE Feedback Page</ulink>.
-      </para>
-<!-- Translators may also add here feedback address for translations -->
-    </legalnotice>
-    <abstract role="description">
-      <para>User manual for <application>Eye of MATE Image Viewer</application>.</para>
-    </abstract>
-
-  </articleinfo> 
+  </info>
 
   <indexterm>
     <primary>Eye of MATE</primary> 
@@ -248,15 +225,15 @@
 <!-- ============= Document Body ============================= -->
 
 <!-- ============= Introduction ============================== -->
-<sect1 id="eom-introduction">
-  <title>Introduction</title>
+<section xml:id="eom-introduction"><info><title>Introduction</title></info>
+  
   <para>The <application>Eye of MATE Image Viewer</application>
   application enables you to view single image files, as well as large image collections.
   </para>
 
-  <sect2 id="eom-tostartapp">
-    <title>Starting &appname;</title>
-    <para>You can start &app; in the following ways:</para>
+  <section xml:id="eom-tostartapp"><info><title>Starting Image Viewer</title></info>
+    
+    <para>You can start <application>Image Viewer</application> in the following ways:</para>
     <itemizedlist>
       <listitem>
         <para>Open an image file in <application>Caja</application>.</para>
@@ -272,18 +249,18 @@
 	<application>Run Application</application> dialog.</para>
       </listitem>
     </itemizedlist>
-  </sect2>
+  </section>
 
-  <sect2 id="eom-closeapp">
-    <title>Closing &appname;</title>
-    <para>To close the current &app; window choose <menuchoice><guimenu>Image</guimenu>
+  <section xml:id="eom-closeapp"><info><title>Closing Image Viewer</title></info>
+    
+    <para>To close the current <application>Image Viewer</application> window choose <menuchoice><guimenu>Image</guimenu>
     <guimenuitem>Close</guimenuitem></menuchoice>, or press
     <keycombo><keycap>Ctrl</keycap><keycap>W</keycap></keycombo>.</para>
-  </sect2>
+  </section>
 
-  <sect2 id="eom-filetypes">
-    <title>Supported File Types</title>
-    <para>&app; supports a variety of image file formats. The following image formats can be opened:</para>
+  <section xml:id="eom-filetypes"><info><title>Supported File Types</title></info>
+    
+    <para><application>Image Viewer</application> supports a variety of image file formats. The following image formats can be opened:</para>
 		<itemizedlist>
 			<listitem><para>ANI - Animation</para>
 			</listitem>
@@ -317,7 +294,7 @@
 			</listitem>
 		</itemizedlist>
 
-  <para>&app; supports the following formats for saving:</para>
+  <para><application>Image Viewer</application> supports the following formats for saving:</para>
 		<itemizedlist>
 			<listitem><para>BMP - Windows Bitmap</para>
 			</listitem>
@@ -328,53 +305,53 @@
 			<listitem><para>PNG - Portable Network Graphics </para>
 			</listitem>
 		</itemizedlist>
-		<para>&app; may be able to open and save other image formats, depending on your system configuration and other installed software.</para>
-  </sect2>
+		<para><application>Image Viewer</application> may be able to open and save other image formats, depending on your system configuration and other installed software.</para>
+  </section>
 
-  <sect2 id="eom-features">
-    <title>&appname; Features</title>
-    <para>&app; has a variety of features to help you view your images.
+  <section xml:id="eom-features"><info><title>Image Viewer Features</title></info>
+    
+    <para><application>Image Viewer</application> has a variety of features to help you view your images.
     You can zoom in and out or view the image full screen. Regardless of
-    your zoom level, &app; uses a low amount of memory. You can also
+    your zoom level, <application>Image Viewer</application> uses a low amount of memory. You can also
     rotate and flip the image you are viewing.</para>
 
     <para>The collection view allows the viewing and editing of large
     image collections. In this view image operations can be applied
     to all selected images at once. </para>
 
-    <para>&app; has special support for digital camera pictures and
+    <para><application>Image Viewer</application> has special support for digital camera pictures and
     displays EXIF metadata recorded with the image. This feature
     requires <systemitem class="library">libexif</systemitem> to be
     installed on your system. All modifications made in JPEG images 
     are lossless. That is, saving rotated and flipped JPEG images 
     will not recompress the image. Beside this all available metadata 
     (like EXIF) will be preserved and updated accordingly. </para>
-  </sect2>
-</sect1>
+  </section>
+</section>
 
 <!--============== When You Start ===========-->
-<sect1 id="eom-whenyoustart">
-  <title>Getting Started</title>
-  <para>When you start &app;, the following window is displayed:</para>
-  <figure id="mainwindow-fig">
-		<title>&appname; Start Up Window</title>
+<section xml:id="eom-whenyoustart"><info><title>Getting Started</title></info>
+  
+  <para>When you start <application>Image Viewer</application>, the following window is displayed:</para>
+  <figure xml:id="mainwindow-fig"><info><title>Image Viewer Start Up Window</title></info>
+		
 		<screenshot>
 		  <mediaobject>
 		    <imageobject>
 		      <imagedata fileref="figures/eom_start_window.png" format="PNG"/>
 		    </imageobject>
 		    <textobject>
-		      <phrase>Shows &app; main window. Contains titlebar, menubar, toolbar, and display area. Menubar contains File, Edit, View, and Help menus.</phrase>
+		      <phrase>Shows <application>Image Viewer</application> main window. Contains titlebar, menubar, toolbar, and display area. Menubar contains File, Edit, View, and Help menus.</phrase>
 		    </textobject>
 		  </mediaobject>
 		</screenshot>
   </figure>
-  <para>The &app; window contains the following elements:</para>
+  <para>The <application>Image Viewer</application> window contains the following elements:</para>
   <variablelist>
 	<varlistentry>
   	  <term>Menubar</term>
  	  <listitem>
-	    <para>The menus on the menubar contain all the commands that you need to work with images in &app;.</para>
+	    <para>The menus on the menubar contain all the commands that you need to work with images in <application>Image Viewer</application>.</para>
 	  </listitem>
  	</varlistentry>
 	<varlistentry>
@@ -408,10 +385,10 @@
 	  </listitem>
 	</varlistentry>
   </variablelist>
-  <para>Most actions in &app; can be performed several ways.  For example,
+  <para>Most actions in <application>Image Viewer</application> can be performed several ways.  For example,
   you can open a file in the following ways:</para>
   <itemizedlist>
-    <listitem><para>Drag an image file into the &app; window from another
+    <listitem><para>Drag an image file into the <application>Image Viewer</application> window from another
     application or window.</para></listitem>
     <listitem><para>Double-click on an image file in the file manager
     or other application.</para></listitem>
@@ -422,18 +399,18 @@
     </keycombo> and select an image file in the <application>Load
     Image</application> dialog.</para></listitem>
   </itemizedlist>
-</sect1>
+</section>
 
 
 <!-- ============= Viewing Images ============================== -->
-<sect1 id="eom-view">
-	<title>Viewing Images</title>
+<section xml:id="eom-view"><info><title>Viewing Images</title></info>
+	
 
 	<!--=========== To Open an Image ============================= -->
-	<sect2 id="eom-open-image">
-		<title>Opening an Image</title>
+	<section xml:id="eom-open-image"><info><title>Opening an Image</title></info>
+		
                 <para>To open an image, perform the following steps:</para>
-                <orderedlist>
+                <orderedlist inheritnum="ignore" continuation="restarts">
                   <listitem>
                     <para>
                       Choose <menuchoice> <guimenu>Image</guimenu><guimenuitem>Open</guimenuitem> </menuchoice>, or press <keycombo> <keycap>Ctrl</keycap><keycap>O</keycap> </keycombo>.  </para>
@@ -445,20 +422,20 @@
                   </listitem>
                   <listitem>
                     <para>
-                      Click <guibutton>Open</guibutton>. &app; displays the name of the image file in the titlebar of the window.
+                      Click <guibutton>Open</guibutton>. <application>Image Viewer</application> displays the name of the image file in the titlebar of the window.
                     </para>
                   </listitem>
                 </orderedlist>
                 <para> 
-	          To open another image, choose <menuchoice> <guimenu>Image</guimenu><guimenuitem>Open</guimenuitem> </menuchoice> again. &app; opens each image in a new window.
+	          To open another image, choose <menuchoice> <guimenu>Image</guimenu><guimenuitem>Open</guimenuitem> </menuchoice> again. <application>Image Viewer</application> opens each image in a new window.
                 </para>
-	</sect2>
+	</section>
 
 	<!--=========== To View the Images in a Directory ==================== -->
-	<sect2 id="eom-open-folder">
-		<title>Viewing the Images in a Folder</title>
+	<section xml:id="eom-open-folder"><info><title>Viewing the Images in a Folder</title></info>
+		
 		<para>To view all images in a folder, perform the following steps:</para>
-                <orderedlist>
+                <orderedlist inheritnum="ignore" continuation="restarts">
                   <listitem>
                     <para>
                       Open one of the images in the folder (see <xref linkend="eom-open-image"/>).  </para>
@@ -472,11 +449,11 @@
 	     <para>The collection shows thumbnails of all supported images in the folder. You can browse the images by clicking on an image in the collection, by choosing the appropriate option in the <guimenu>Go</guimenu> menu or by pressing <keycombo><keycap>Alt</keycap><keycap>Left</keycap></keycombo> or <keycombo><keycap>Alt</keycap><keycap>Right</keycap></keycombo>.</para>
              <para>To view all the directory images in fullscreen, choose <menuchoice> <guimenu>View</guimenu><guimenuitem>Full Screen</guimenuitem> </menuchoice> or press <keycap>F11</keycap>. To view them as a slide show, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Slideshow</guimenuitem></menuchoice> or press <keycap>F5</keycap>. To return to the collection view, press the <keycap>Esc</keycap> key, or <keycombo><keycap>Ctrl</keycap><keycap>W</keycap></keycombo>. For more information about how to customize the slide show, see <xref linkend="eom-prefs-slideshow"/>.
                     </para>
-	</sect2>
+	</section>
 
 	<!--============ To Scroll an Image ======================= -->
-	<sect2 id="eom-scroll-image">
-		<title>Scrolling an Image</title>
+	<section xml:id="eom-scroll-image"><info><title>Scrolling an Image</title></info>
+		
 		<para>To scroll around an image that is larger than the image window or full screen view, you can use the following methods:</para>
 		<itemizedlist>
 			<listitem><para>Use the arrow keys on the keyboard.</para>
@@ -486,11 +463,11 @@
 			<listitem><para>Use the scrollbars on the window.</para>
 			</listitem>
 		</itemizedlist>
-	</sect2>
+	</section>
 
 	<!--=========== To Zoom In and Out ==================== -->
-	<sect2 id="eom-zoom">
-		<title>Zooming</title>
+	<section xml:id="eom-zoom"><info><title>Zooming</title></info>
+		
 		<para>You can zoom in or out of the image in the following ways:</para>
 			<itemizedlist>
 				<listitem><para>Use the <mousebutton>scroll wheel</mousebutton> on your mouse. Scrolling down zooms out; scrolling up zooms in.</para></listitem>
@@ -504,31 +481,31 @@
 				<listitem><para>Use the keyboard. To zoom in, <keycombo> <keycap>Ctrl</keycap><keycap>+</keycap> </keycombo> or <keycap>+</keycap>. To zoom out, <keycombo> <keycap>Ctrl</keycap><keycap>-</keycap> </keycombo> or <keycap>-</keycap>. To go back to the normal size, <keycombo> <keycap>Ctrl</keycap><keycap>0</keycap> </keycombo> or <keycap>1</keycap>. To scale the image to fit the window, press <keycap>F</keycap>.</para></listitem>
 			</itemizedlist>
 			<para>When an image is zoomed to fit the window, resizing the window will also change the zoom level, so the image still fits the window.</para>
-	</sect2>
+	</section>
 
 	<!--=========== To View Image Fullscreen ==================== -->
-	<sect2 id="eom-fullscreen">
-		<title>Viewing an Image Full Screen/Slideshow</title>
+	<section xml:id="eom-fullscreen"><info><title>Viewing an Image Full Screen/Slideshow</title></info>
+		
 		<para>To show the image using the entire screen,  choose <menuchoice><guimenu>View</guimenu><guimenuitem>Full Screen</guimenuitem></menuchoice>.</para>
 		<para>No panels, window frames, or menubars are visible when an image is shown like this. To return to the normal view, press <keycap>Esc</keycap>, or <keycap>F11</keycap>, or <keycombo><keycap>Ctrl</keycap><keycap>W</keycap></keycombo>.</para>
 		<para>You can zoom or scroll around the image in the same way as when it is shown in a window, using the mouse or the keyboard.</para>
 		<para>If you have multiple images in your collection you can press <keycap>Space</keycap> or use the right/down cursor keys to advance to the next image. The previous image can be reached by pressing <keycap>Backspace</keycap> or using the left/up cursor keys.</para>
-	<para>In this case you can also use the slideshow mode, where &app; automatically switches to the next image in your collection. You can start a slideshow by choosing <menuchoice><guimenu>View</guimenu><guimenuitem>Slideshow</guimenuitem></menuchoice> or by pressing <keycap>F5</keycap>. The slideshow can be paused/continued by pressing <keycap>P</keycap>. To stop the slideshow, press the <keycap>Esc</keycap> or <keycap>F5</keycap> key, or <keycombo><keycap>Ctrl</keycap><keycap>W</keycap></keycombo>. For more information about how to customize the slide show, see <xref linkend="eom-prefs-slideshow"/>. </para>
-	</sect2>
-</sect1>
+	<para>In this case you can also use the slideshow mode, where <application>Image Viewer</application> automatically switches to the next image in your collection. You can start a slideshow by choosing <menuchoice><guimenu>View</guimenu><guimenuitem>Slideshow</guimenuitem></menuchoice> or by pressing <keycap>F5</keycap>. The slideshow can be paused/continued by pressing <keycap>P</keycap>. To stop the slideshow, press the <keycap>Esc</keycap> or <keycap>F5</keycap> key, or <keycombo><keycap>Ctrl</keycap><keycap>W</keycap></keycombo>. For more information about how to customize the slide show, see <xref linkend="eom-prefs-slideshow"/>. </para>
+	</section>
+</section>
 
 
 <!-- ============= Manipulating Images ============================== -->
-<sect1 id="eom-manipulate">
-	<title>Manipulating Images</title>
+<section xml:id="eom-manipulate"><info><title>Manipulating Images</title></info>
+	
 
 	<para>All image manipulations apply to all selected images at once. The modifications are done
 	in memory and alter the original files on disk only when the images are saved with the save function (see <xref linkend="eom-save-image"/>).
 	</para>
 
 	<!--============ To Flip an Image ======================= -->
-	<sect2 id="eom-flip">
-		<title>Flipping an Image</title>
+	<section xml:id="eom-flip"><info><title>Flipping an Image</title></info>
+		
 		<para>To flip an image along the horizontal axis of the image, choose 
 		<menuchoice>
 		<guimenu>Edit</guimenu>
@@ -539,11 +516,11 @@
 		<guimenu>Edit</guimenu>
 		<guimenuitem>Flip Vertical</guimenuitem>
 		</menuchoice>.</para>
-	</sect2>
+	</section>
 
 	<!--============ To Rotate an Image ======================= -->
-	<sect2 id="eom-rotate">
-		<title>Rotating an Image</title>
+	<section xml:id="eom-rotate"><info><title>Rotating an Image</title></info>
+		
 		<para>To rotate an image 90 degrees in a clockwise direction, choose 
 		<menuchoice>
 		<guimenu>Edit</guimenu>
@@ -554,11 +531,11 @@
 		<guimenu>Edit</guimenu>
 		<guimenuitem>Rotate Counterclockwise</guimenuitem>
 		</menuchoice>.</para>
-	</sect2>
+	</section>
 
 	<!--============ To Undo an Action ======================= -->
-	<sect2 id="eom-undo">
-		<title>Undoing an Action</title>
+	<section xml:id="eom-undo"><info><title>Undoing an Action</title></info>
+		
 		<para>To undo a flip or rotate action, choose 
 		<menuchoice>
 		<guimenu>Edit</guimenu>
@@ -566,59 +543,58 @@
 		</menuchoice> or press 
 		<keycombo><keycap>Ctrl</keycap><keycap>Z</keycap></keycombo>
 		.</para>
-	</sect2>
+	</section>
 
 	<!--============ To Delete An Image ======================== -->
-	<sect2 id="eom-delete-image">
-		<title>Deleting an Image</title>
+	<section xml:id="eom-delete-image"><info><title>Deleting an Image</title></info>
+		
 		<para>To move an image to the Trash, choose
 			<menuchoice>
 			<guimenu>Edit</guimenu>
 			<guimenuitem>Move to Trash</guimenuitem>
 			</menuchoice>.
 			This moves the file to the Trash folder. Multiple images can also be moved to the trash in the same way: select them all first.</para>
-	    <para>To restore an image from the Trash, open the Trash folder in <application>Caja</application> file manager and move the image file to another folder. To delete the image permanently, empty the Trash. To find out more about using the Trash, see the <ulink type="help" url="help:mate-user-guide/caja-trash">Desktop User Guide</ulink>.</para>
+	    <para>To restore an image from the Trash, open the Trash folder in <application>Caja</application> file manager and move the image file to another folder. To delete the image permanently, empty the Trash. To find out more about using the Trash, see the <link xlink:href="help:mate-user-guide/caja-trash">Desktop User Guide</link>.</para>
 				
 			<note><para>You can also use the <keycap>Del</keycap> key to move an image to the Trash, in which case you will be asked for confirmation.</para></note>
 			
-	</sect2>
-</sect1> 
+	</section>
+</section> 
 
 <!-- ============= Saving Images ============================== -->
-<sect1 id="eom-save-rename">
-	<title>Saving Images</title>
+<section xml:id="eom-save-rename"><info><title>Saving Images</title></info>
+	
 
 	<para>
-	&app; always tries to choose the save method with the least impact to the image data. For example, if an otherwise unmodified image is saved under a different name in the same format, the file is simply copied. If <systemitem
-    class="library">libjpeg</systemitem> is available on the system all JPEG image modifications are done without loss of image information.
+	<application>Image Viewer</application> always tries to choose the save method with the least impact to the image data. For example, if an otherwise unmodified image is saved under a different name in the same format, the file is simply copied. If <systemitem class="library">libjpeg</systemitem> is available on the system all JPEG image modifications are done without loss of image information.
 	</para>
 
 <!--============ To Save an Image ======================= -->
-	<sect2 id="eom-save-image">
-		<title>Saving an Image</title>
+	<section xml:id="eom-save-image"><info><title>Saving an Image</title></info>
+		
 		<para>To save an image, choose 
 			<menuchoice>
 			<guimenu>Image</guimenu>
 			<guimenuitem>Save</guimenuitem>
 			</menuchoice>.
 		The image will be saved under the same name and file type. Therefore, unmodified images needn't be saved.</para>
-	</sect2>
+	</section>
 
 	<!--============ To Save As an Image ======================= -->
-	<sect2 id="eom-save-as-image">
-		<title>Saving an Image under a Different Name</title>
+	<section xml:id="eom-save-as-image"><info><title>Saving an Image under a Different Name</title></info>
+		
 		<para>To save an image under a different name, or convert it to a different file type, choose
 			<menuchoice>
 			<guimenu>Image</guimenu>
 			<guimenuitem>Save As</guimenuitem>
 			</menuchoice>.</para>
-		<para>Specify the filename in the <guilabel>Name</guilabel> field in the <guilabel>Save Image</guilabel> dialog, then click <guibutton>Save</guibutton>. The file is saved in the current folder by default. &app; tries to determine the file type from the given filename suffix. If the image should be saved in another folder or the file type detection failed, expand the dialog by clicking on <guilabel>Browse for other folders</guilabel>. This allows further folder navigation and the specification of the file type from the drop down box.</para>
+		<para>Specify the filename in the <guilabel>Name</guilabel> field in the <guilabel>Save Image</guilabel> dialog, then click <guibutton>Save</guibutton>. The file is saved in the current folder by default. <application>Image Viewer</application> tries to determine the file type from the given filename suffix. If the image should be saved in another folder or the file type detection failed, expand the dialog by clicking on <guilabel>Browse for other folders</guilabel>. This allows further folder navigation and the specification of the file type from the drop down box.</para>
 		<para>You can save multiple images at once: see the next section.</para>
-	</sect2>    
+	</section>    
 
 	<!--============ To Save As an Image ======================= -->
-	<sect2 id="eom-save-as-multiple">
-		<title>Saving Multiple Images</title>
+	<section xml:id="eom-save-as-multiple"><info><title>Saving Multiple Images</title></info>
+		
 		<para>Saving multiple images at once allows you to convert several images to a different format, or give them similar filenames.</para>
 		<para>To save multiple images, select the images and choose 
 			<menuchoice>
@@ -626,8 +602,8 @@
 			<guimenuitem>Save As</guimenuitem>
 			</menuchoice>. 		
 		The following window is displayed:</para>
-  		<figure id="saveas-dialog-fig">
-			<title>Save As dialog for multiple images</title>
+  		<figure xml:id="saveas-dialog-fig"><info><title>Save As dialog for multiple images</title></info>
+			
 			<screenshot>
 			  <mediaobject>
 			    <imageobject>
@@ -654,24 +630,24 @@
 		<para>The <guilabel>Options</guilabel> section allows to remove all space characters by underscores in the resulting filename if <guilabel>Replace spaces with underscores</guilabel> is checked. The <guilabel>Start counter at</guilabel> spin box determines at which number the counter starts if you use the %n tag for the file format specification.</para>
 		<para>The <guilabel>File Name Preview</guilabel> section of the dialog shows the resulting file name according to the above settings for an example filename from the selected images.
 		</para>
-	</sect2>
+	</section>
 
 
 
-</sect1>
+</section>
 
-<sect1 id="eom-print">
-	<title>Printing Images</title>
-	<sect2 id="eom-print-pagesettings">
-		<title>Setting your Page Settings</title>
+<section xml:id="eom-print"><info><title>Printing Images</title></info>
+	
+	<section xml:id="eom-print-pagesettings"><info><title>Setting your Page Settings</title></info>
+		
 		<para>Before printing you need to set the page settings you would like to use. To do that choose <menuchoice><guimenu>Image</guimenu><guimenuitem>Page Setup</guimenuitem></menuchoice>.</para>
 		<para>In the <guilabel>Page Setup</guilabel> dialog you can now choose paper size and orientation. If possible, configure your printer to have the page borders set correctly.</para>
-	</sect2>
+	</section>
 
-	<sect2 id="eom-print-image">
-		<title>Printing an Image</title>
+	<section xml:id="eom-print-image"><info><title>Printing an Image</title></info>
+		
 		<para>To print an image, perform the following steps:</para>
-		<orderedlist>
+		<orderedlist inheritnum="ignore" continuation="restarts">
 			<listitem>
 				<para>Select <menuchoice><guimenu>Image</guimenu><guimenuitem>Print</guimenuitem></menuchoice></para>
 			</listitem>
@@ -679,17 +655,17 @@
 				<para>In the <guilabel>Print</guilabel> dialog, select the printer you want to use from the list.</para>
 			</listitem>
 			<listitem>
-				<para>Click <guilabel>Print</guilabel>. &app; starts printing now.</para>
+				<para>Click <guilabel>Print</guilabel>. <application>Image Viewer</application> starts printing now.</para>
 			</listitem>
 		</orderedlist>
 		<para>Images that are too large for the page are automatically scaled down to fit the page. Images that are smaller than the page are centered on it.</para>
 		<important>
-			<para>Please note that &app; is currently lacking progress reporting while printing. During that time the user interface might become unresponsive for a short time.</para>
+			<para>Please note that <application>Image Viewer</application> is currently lacking progress reporting while printing. During that time the user interface might become unresponsive for a short time.</para>
 		</important>
-	</sect2>
+	</section>
 
-	<sect2 id="eom-print-settings">
-		<title>Arranging an Image on the Page</title>
+	<section xml:id="eom-print-settings"><info><title>Arranging an Image on the Page</title></info>
+		
 		<para>Maybe you don't want your image centered or want it scaled down even further. To do that you need to open the <guilabel>Print</guilabel> dialog (see <xref linkend="eom-print-image"/>) and then select the <guilabel>Image Settings</guilabel> tab which offers you the following options:</para>
 		<itemizedlist>
 			<listitem>
@@ -705,17 +681,17 @@
 				<para>The <guilabel>Unit</guilabel> option allows you to change the metric unit which is used by the options on the <guilabel>Image Settings</guilabel> tab. When you change this option the other fields values are converted accordingly.</para>
 			</listitem>
 		</itemizedlist>
-	</sect2>
+	</section>
 		
-</sect1>
-<sect1 id="eom-toolbareditor">
-	<title>Personalizing The Toolbar</title>
-	<para>&appname;'s default toolbar contains only a basic set of items to keep it simple. But you can modify the toolbar if you prefer a different set.</para>
-	<sect2 id="eom-toolbareditor-use">
-		<title>Modifying the Toolbar</title>
+</section>
+<section xml:id="eom-toolbareditor"><info><title>Personalizing The Toolbar</title></info>
+	
+	<para>Image Viewer's default toolbar contains only a basic set of items to keep it simple. But you can modify the toolbar if you prefer a different set.</para>
+	<section xml:id="eom-toolbareditor-use"><info><title>Modifying the Toolbar</title></info>
+		
 		<para>If you want to modify the toolbar you need to open the toolbar editor by going to <menuchoice><guimenu>Edit</guimenu><guimenuitem>Toolbar</guimenuitem></menuchoice>. The following window will pop up:</para>
-		<figure id="toolbar-editor-fig">
-			<title>The toolbar editor window</title>
+		<figure xml:id="toolbar-editor-fig"><info><title>The toolbar editor window</title></info>
+			
 			<screenshot>
 				<mediaobject>
 					<imageobject>
@@ -740,11 +716,11 @@
 			</listitem>
 		</itemizedlist>
 		<para>When you have finished editing the toolbar, click the <guibutton>Close</guibutton> button in the toolbar editor window. This will close the toolbar editor and make your modified toolbar active.</para>
-		</sect2>
-		<sect2 id="eom-toolbareditor-reset">
-			<title>Resetting the Toolbar</title>
+		</section>
+		<section xml:id="eom-toolbareditor-reset"><info><title>Resetting the Toolbar</title></info>
+			
 			<para>To revert your changes to the toolbar and return to the default layout, perform the following steps:</para>
-			<orderedlist>
+			<orderedlist inheritnum="ignore" continuation="restarts">
 				<listitem>
 					<para>Open the toolbar editor (see <xref linkend="eom-toolbareditor-use"/>).</para>
 				</listitem>
@@ -755,20 +731,20 @@
 					<para>Click the <guibutton>Close</guibutton> button to close the toolbar editor. The toolbar has been reset to the default layout now.</para>
 				</listitem>
 			</orderedlist>
-		</sect2>
-</sect1>
-<sect1 id="eom-prefs">
-	<title>Preferences</title>
+		</section>
+</section>
+<section xml:id="eom-prefs"><info><title>Preferences</title></info>
+	
 	<para>Preferences can be changed by going to <menuchoice><guimenu>Edit</guimenu><guimenuitem>Preferences</guimenuitem></menuchoice>. You will be able to change the options for image viewing and slide shows. The changes apply to all open windows instantly.</para>
 
 	<!--============ Image View ======================= -->
-  <sect2 id="eom-prefs-image">
-         <title>Image View</title>
+  <section xml:id="eom-prefs-image"><info><title>Image View</title></info>
+         
 	<variablelist>
 	<varlistentry>
 		<term><guilabel>Image Enhancements</guilabel></term>
 		<listitem>
-		<para>Select the <guilabel>Smooth images when zoomed</guilabel> option to enable image smoothing when you change the image's zoom factor. If you select this option, your images will be smoothed to improve their display quality while viewing them with &app;.</para>
+		<para>Select the <guilabel>Smooth images when zoomed</guilabel> option to enable image smoothing when you change the image's zoom factor. If you select this option, your images will be smoothed to improve their display quality while viewing them with <application>Image Viewer</application>.</para>
                 <para>If you select the <guilabel>Automatic orientation</guilabel> option, your images will be rotated on loading according to their metadata. For example portraits are automatically rotated upright. Note that this function requires a correctly set orientation tag in the image's metadata and thus does not work with all images. The rotation is not saved until you save the rotated image (see <xref linkend="eom-save-rename"/>).</para>
 		</listitem>
 	</varlistentry>
@@ -776,7 +752,7 @@
 	<varlistentry>
 		<term><guilabel>Transparent Parts</guilabel></term>
 		<listitem>
-		<para>Select one of the following options to determine how &app; displays transparent parts of an image:</para>
+		<para>Select one of the following options to determine how <application>Image Viewer</application> displays transparent parts of an image:</para>
 		<itemizedlist>
 			<listitem><para><guilabel>As check pattern</guilabel> </para>
 			<para>Displays any transparent parts of the image in a check pattern.</para>
@@ -785,17 +761,17 @@
 			<para>Displays any transparent parts of the image in a solid color that you specify. Click on the color selector button to select a color. </para>
 			</listitem>
 			<listitem><para><guimenuitem>As background</guimenuitem> </para>
-			<para>Displays any transparent parts of the image in the background color of the &app; application. </para>
+			<para>Displays any transparent parts of the image in the background color of the <application>Image Viewer</application> application. </para>
 			</listitem>
 		</itemizedlist>
 		</listitem>
 	</varlistentry>		
 	</variablelist>
-  </sect2>
+  </section>
 		
 	<!--============ Slide Show ==================-->                                                                                               
-  <sect2 id="eom-prefs-slideshow">
-         <title>Slideshow</title>
+  <section xml:id="eom-prefs-slideshow"><info><title>Slideshow</title></info>
+         
 	<variablelist>
 	<varlistentry>
 		<term><guilabel>Image Zoom</guilabel></term>
@@ -813,6 +789,6 @@
 		</listitem>
 	</varlistentry>		
 	</variablelist>
-  </sect2>
-</sect1>
+  </section>
+</section>
 </article>

--- a/help/C/index.docbook
+++ b/help/C/index.docbook
@@ -18,7 +18,7 @@
     <title>Image Viewer Manual</title>
 
     <copyright>
-      <year>2015</year>
+      <year>2019</year>
       <holder>MATE Documentation Project</holder>
     </copyright>
     <copyright> 

--- a/help/C/legal.xml
+++ b/help/C/legal.xml
@@ -1,12 +1,13 @@
-   <legalnotice id="legalnotice">
+<legalnotice xmlns="http://docbook.org/ns/docbook"
+             xmlns:xlink="http://www.w3.org/1999/xlink"
+             version="5.0" xml:id="legalnotice" xml:lang="en">
          <para>
            Permission is granted to copy, distribute and/or modify this
            document under the terms of the GNU Free Documentation
            License (GFDL), Version 1.1 or any later version published
            by the Free Software Foundation with no Invariant Sections,
            no Front-Cover Texts, and no Back-Cover Texts.  You can find
-           a copy of the GFDL at this <ulink type="help"
-           url="help:fdl">link</ulink> or in the file COPYING-DOCS
+           a copy of the GFDL at this <link xlink:href="https://www.gnu.org/licenses/fdl-1.1.html">link</link> or in the file COPYING-DOCS
            distributed with this manual.
           </para>
           <para> This manual is part of a collection of MATE manuals
@@ -72,5 +73,8 @@
                  </listitem>
            </orderedlist>
          </para>
+        <formalpara>
+            <title>Feedback</title>
+            <para>To report a bug or make a suggestion regarding the <application>Image Viewer</application> application or this manual, follow the directions in the <link xlink:href="help:mate-user-guide/feedback">MATE Feedback Page</link>.</para>
+        </formalpara>
    </legalnotice>
- 

--- a/help/eom.pot
+++ b/help/eom.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MATE Desktop Environment\n"
-"POT-Creation-Date: 2019-02-04 11:52+0100\n"
+"POT-Creation-Date: 2019-02-07 10:05+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,409 +14,359 @@ msgctxt "_"
 msgid "translator-credits"
 msgstr ""
 
-#. (itstool) path: articleinfo/title
-#: C/index.docbook:24
+#. (itstool) path: info/title
+#: C/index.docbook:18
 msgid "Image Viewer Manual"
 msgstr ""
 
-#. (itstool) path: articleinfo/copyright
-#: C/index.docbook:26
+#. (itstool) path: info/copyright
+#: C/index.docbook:20
 msgid "<year>2015</year> <holder>MATE Documentation Project</holder>"
 msgstr ""
 
-#. (itstool) path: articleinfo/copyright
-#: C/index.docbook:30
+#. (itstool) path: info/copyright
+#: C/index.docbook:24
 msgid "<year>2006</year> <year>2007</year> <holder>GNOME Documentation Project</holder>"
 msgstr ""
 
-#. (itstool) path: articleinfo/copyright
-#: C/index.docbook:35
+#. (itstool) path: info/copyright
+#: C/index.docbook:29
 msgid "<year>2002</year> <year>2003</year> <year>2004</year> <holder>Sun Microsystems</holder>"
 msgstr ""
 
-#. (itstool) path: articleinfo/copyright
-#: C/index.docbook:41
+#. (itstool) path: info/copyright
+#: C/index.docbook:35
 msgid "<year>2000</year> <holder>Eliot Landrum</holder>"
 msgstr ""
 
-#. (itstool) path: articleinfo/copyright
-#: C/index.docbook:45
+#. (itstool) path: info/copyright
+#: C/index.docbook:39
 msgid "<year>2000</year> <holder>The Free Software Foundation</holder>"
 msgstr ""
 
 #. (itstool) path: publisher/publishername
 #. (itstool) path: revdescription/para
-#: C/index.docbook:61
-#: C/index.docbook:140
-#: C/index.docbook:141
+#: C/index.docbook:48
+#: C/index.docbook:127
+#: C/index.docbook:128
 msgid "MATE Documentation Project"
 msgstr ""
 
 #. (itstool) path: publisher/publishername
 #. (itstool) path: revdescription/para
-#: C/index.docbook:64
-#: C/index.docbook:148
-#: C/index.docbook:149
-#: C/index.docbook:157
-#: C/index.docbook:165
-#: C/index.docbook:173
-#: C/index.docbook:181
-#: C/index.docbook:189
-#: C/index.docbook:197
-#: C/index.docbook:205
+#: C/index.docbook:51
+#: C/index.docbook:135
+#: C/index.docbook:136
+#: C/index.docbook:144
+#: C/index.docbook:152
+#: C/index.docbook:160
+#: C/index.docbook:168
+#: C/index.docbook:176
+#: C/index.docbook:184
+#: C/index.docbook:192
+#: C/index.docbook:200
 #: C/index.docbook:213
-#: C/index.docbook:226
 msgid "GNOME Documentation Project"
 msgstr ""
 
-#. (itstool) path: legalnotice/para
-#: C/index.docbook:2
-msgid "Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License (GFDL), Version 1.1 or any later version published by the Free Software Foundation with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts. You can find a copy of the GFDL at this <ulink type=\"help\" url=\"help:fdl\">link</ulink> or in the file COPYING-DOCS distributed with this manual."
-msgstr ""
-
-#. (itstool) path: legalnotice/para
-#: C/index.docbook:12
-#: C/legal.xml:12
-msgid "This manual is part of a collection of MATE manuals distributed under the GFDL. If you want to distribute this manual separately from the collection, you can do so by adding a copy of the license to the manual, as described in section 6 of the license."
-msgstr ""
-
-#. (itstool) path: legalnotice/para
-#: C/index.docbook:19
-#: C/legal.xml:19
-msgid "Many of the names used by companies to distinguish their products and services are claimed as trademarks. Where those names appear in any MATE documentation, and the members of the MATE Documentation Project are made aware of those trademarks, then the names are in capital letters or initial capital letters."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:35
-#: C/legal.xml:35
-msgid "DOCUMENT IS PROVIDED ON AN \"AS IS\" BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, WITHOUT LIMITATION, WARRANTIES THAT THE DOCUMENT OR MODIFIED VERSION OF THE DOCUMENT IS FREE OF DEFECTS MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY, ACCURACY, AND PERFORMANCE OF THE DOCUMENT OR MODIFIED VERSION OF THE DOCUMENT IS WITH YOU. SHOULD ANY DOCUMENT OR MODIFIED VERSION PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE INITIAL WRITER, AUTHOR OR ANY CONTRIBUTOR) ASSUME THE COST OF ANY NECESSARY SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE OF ANY DOCUMENT OR MODIFIED VERSION OF THE DOCUMENT IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS DISCLAIMER; AND"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:55
-#: C/legal.xml:55
-msgid "UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER IN TORT (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL THE AUTHOR, INITIAL WRITER, ANY CONTRIBUTOR, OR ANY DISTRIBUTOR OF THE DOCUMENT OR MODIFIED VERSION OF THE DOCUMENT, OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE LIABLE TO ANY PERSON FOR ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF GOODWILL, WORK STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER DAMAGES OR LOSSES ARISING OUT OF OR RELATING TO USE OF THE DOCUMENT AND MODIFIED VERSIONS OF THE DOCUMENT, EVEN IF SUCH PARTY SHALL HAVE BEEN INFORMED OF THE POSSIBILITY OF SUCH DAMAGES."
-msgstr ""
-
-#. (itstool) path: legalnotice/para
-#: C/index.docbook:28
-#: C/legal.xml:28
-msgid "DOCUMENT AND MODIFIED VERSIONS OF THE DOCUMENT ARE PROVIDED UNDER THE TERMS OF THE GNU FREE DOCUMENTATION LICENSE WITH THE FURTHER UNDERSTANDING THAT: <_:orderedlist-1/>"
+#. (itstool) path: authorgroup/author
+#: C/index.docbook:60
+msgid "<orgname>MATE Documentation Project</orgname> <affiliation> <orgname>MATE Desktop</orgname> </affiliation>"
 msgstr ""
 
 #. (itstool) path: authorgroup/author
-#: C/index.docbook:72
-msgid "<firstname>MATE Documentation Project</firstname> <surname/> <affiliation> <orgname>MATE Desktop</orgname> </affiliation>"
+#: C/index.docbook:66
+msgid "<personname> <firstname>Jens</firstname> <surname>Finke</surname> </personname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation>"
 msgstr ""
 
 #. (itstool) path: authorgroup/author
-#: C/index.docbook:79
-msgid "<firstname>Jens</firstname> <surname>Finke</surname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation>"
+#: C/index.docbook:75
+msgid "<personname> <firstname>Angela</firstname> <surname>Boyle</surname> </personname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation>"
 msgstr ""
 
 #. (itstool) path: authorgroup/author
-#: C/index.docbook:86
-msgid "<firstname>Angela</firstname> <surname>Boyle</surname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation>"
+#: C/index.docbook:84
+msgid "<personname> <firstname>Stuart</firstname> <surname>Ellis</surname> </personname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation>"
 msgstr ""
 
 #. (itstool) path: authorgroup/author
 #: C/index.docbook:93
-msgid "<firstname>Stuart</firstname> <surname>Ellis</surname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation>"
+msgid "<personname> <firstname>Sun</firstname> <surname>GNOME Documentation Team</surname> </personname> <affiliation> <orgname>Sun Microsystems</orgname> </affiliation>"
 msgstr ""
 
 #. (itstool) path: authorgroup/author
-#: C/index.docbook:100
-msgid "<firstname>Sun</firstname> <surname>GNOME Documentation Team</surname> <affiliation> <orgname>Sun Microsystems</orgname> </affiliation>"
+#: C/index.docbook:102
+msgid "<personname> <firstname>Eliot</firstname> <surname>Landrum</surname> </personname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation>"
 msgstr ""
 
 #. (itstool) path: authorgroup/author
-#: C/index.docbook:107
-msgid "<firstname>Eliot</firstname> <surname>Landrum</surname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation>"
-msgstr ""
-
-#. (itstool) path: authorgroup/author
-#: C/index.docbook:114
-msgid "<firstname>Federico</firstname> <surname>Mena Quintero</surname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation>"
+#: C/index.docbook:111
+msgid "<personname> <firstname>Federico</firstname> <surname>Mena Quintero</surname> </personname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:136
-msgid "<revnumber>Image Viewer Manual V2.9</revnumber> <date>July 2015</date> <_:revdescription-1/>"
+#: C/index.docbook:123
+msgid "<revnumber>2.9</revnumber> <date>July 2015</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:144
-msgid "<revnumber>Eye of GNOME Manual V2.8</revnumber> <date>February 2007</date> <_:revdescription-1/>"
+#: C/index.docbook:131
+msgid "<revnumber>2.8</revnumber> <date>February 2007</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revdescription/para
-#: C/index.docbook:156
-#: C/index.docbook:164
-#: C/index.docbook:172
-#: C/index.docbook:180
-#: C/index.docbook:188
-#: C/index.docbook:196
-#: C/index.docbook:204
-#: C/index.docbook:212
+#: C/index.docbook:143
+#: C/index.docbook:151
+#: C/index.docbook:159
+#: C/index.docbook:167
+#: C/index.docbook:175
+#: C/index.docbook:183
+#: C/index.docbook:191
+#: C/index.docbook:199
 msgid "Sun GNOME Documentation Team"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:152
-msgid "<revnumber>Eye of GNOME Manual V2.7</revnumber> <date>February 2004</date> <_:revdescription-1/>"
+#: C/index.docbook:139
+msgid "<revnumber>2.7</revnumber> <date>February 2004</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:160
-msgid "<revnumber>Eye of GNOME Manual V2.6</revnumber> <date>November 2003</date> <_:revdescription-1/>"
+#: C/index.docbook:147
+msgid "<revnumber>2.6</revnumber> <date>November 2003</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:168
-msgid "<revnumber>Eye of GNOME Manual V2.5</revnumber> <date>September 2003</date> <_:revdescription-1/>"
+#: C/index.docbook:155
+msgid "<revnumber>2.5</revnumber> <date>September 2003</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:176
-msgid "<revnumber>Eye of GNOME Manual V2.4</revnumber> <date>January 2003</date> <_:revdescription-1/>"
+#: C/index.docbook:163
+msgid "<revnumber>2.4</revnumber> <date>January 2003</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:184
-msgid "<revnumber>Eye of GNOME Manual V2.3</revnumber> <date>October 2002</date> <_:revdescription-1/>"
+#: C/index.docbook:171
+msgid "<revnumber>2.3</revnumber> <date>October 2002</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:192
-msgid "<revnumber>Eye of GNOME Manual V2.2</revnumber> <date>August 2002</date> <_:revdescription-1/>"
+#: C/index.docbook:179
+msgid "<revnumber>2.2</revnumber> <date>August 2002</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:200
-msgid "<revnumber>Eye of GNOME Manual V2.1</revnumber> <date>July 2002</date> <_:revdescription-1/>"
+#: C/index.docbook:187
+msgid "<revnumber>2.1</revnumber> <date>July 2002</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:208
-msgid "<revnumber>Eye of GNOME Manual V2.0</revnumber> <date>May 2002</date> <_:revdescription-1/>"
+#: C/index.docbook:195
+msgid "<revnumber>2.0</revnumber> <date>May 2002</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revdescription/para
-#: C/index.docbook:220
+#: C/index.docbook:207
 msgid "Eliot Landrum <email>eliot@landrum.cx</email>"
 msgstr ""
 
 #. (itstool) path: revdescription/para
-#: C/index.docbook:223
+#: C/index.docbook:210
 msgid "Federico Mena Quintero <email>federico@gnu.org</email>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:216
-msgid "<revnumber>Eye of GNOME User's Guide</revnumber> <date>2000</date> <_:revdescription-1/>"
+#: C/index.docbook:203
+msgid "<revnumber>1.0</revnumber> <date>2000</date> <_:revdescription-1/>"
 msgstr ""
 
-#. (itstool) path: articleinfo/releaseinfo
-#: C/index.docbook:230
+#. (itstool) path: info/releaseinfo
+#: C/index.docbook:217
 msgid "This manual describes version 1.10.2 of Image Viewer."
 msgstr ""
 
-#. (itstool) path: legalnotice/title
-#: C/index.docbook:233
-msgid "Feedback"
-msgstr ""
-
-#. (itstool) path: legalnotice/para
-#: C/index.docbook:234
-msgid "To report a bug or make a suggestion regarding the Image Viewer application or this manual, follow the directions in the <ulink url=\"help:mate-user-guide/feedback\" type=\"help\">MATE Feedback Page</ulink>."
-msgstr ""
-
-#. (itstool) path: abstract/para
-#: C/index.docbook:239
-msgid "User manual for <application>Eye of MATE Image Viewer</application>."
-msgstr ""
-
 #. (itstool) path: article/indexterm
-#: C/index.docbook:244
+#: C/index.docbook:221
 msgid "<primary>Eye of MATE</primary>"
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/index.docbook:252
+#. (itstool) path: info/title
+#: C/index.docbook:228
 msgid "Introduction"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:253
+#. (itstool) path: section/para
+#: C/index.docbook:230
 msgid "The <application>Eye of MATE Image Viewer</application> application enables you to view single image files, as well as large image collections."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:258
+#. (itstool) path: info/title
+#: C/index.docbook:234
 msgid "Starting Image Viewer"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:259
+#. (itstool) path: section/para
+#: C/index.docbook:236
 msgid "You can start <application>Image Viewer</application> in the following ways:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:262
+#: C/index.docbook:239
 msgid "Open an image file in <application>Caja</application>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:265
+#: C/index.docbook:242
 msgid "Choose <menuchoice><guimenu>Graphics</guimenu> <guimenuitem>Image Viewer</guimenuitem></menuchoice> from the <guimenu>Applications</guimenu> menu."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:270
+#: C/index.docbook:247
 msgid "Run <command>eom</command> at the prompt in a terminal such as <application>mate-terminal</application>, or from the <application>Run Application</application> dialog."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:278
+#. (itstool) path: info/title
+#: C/index.docbook:254
 msgid "Closing Image Viewer"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:279
+#. (itstool) path: section/para
+#: C/index.docbook:256
 msgid "To close the current <application>Image Viewer</application> window choose <menuchoice><guimenu>Image</guimenu> <guimenuitem>Close</guimenuitem></menuchoice>, or press <keycombo><keycap>Ctrl</keycap><keycap>W</keycap></keycombo>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:285
+#. (itstool) path: info/title
+#: C/index.docbook:261
 msgid "Supported File Types"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:286
+#. (itstool) path: section/para
+#: C/index.docbook:263
 msgid "<application>Image Viewer</application> supports a variety of image file formats. The following image formats can be opened:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:288
+#: C/index.docbook:265
 msgid "ANI - Animation"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:290
-#: C/index.docbook:322
+#: C/index.docbook:267
+#: C/index.docbook:299
 msgid "BMP - Windows Bitmap"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:292
+#: C/index.docbook:269
 msgid "GIF - Graphics Interchange Format"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:294
-#: C/index.docbook:324
+#: C/index.docbook:271
+#: C/index.docbook:301
 msgid "ICO - Windows Icon"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:296
-#: C/index.docbook:326
+#: C/index.docbook:273
+#: C/index.docbook:303
 msgid "JPEG - Joint Photographic Experts Group"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:298
+#: C/index.docbook:275
 msgid "PCX - PC Paintbrush"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:300
-#: C/index.docbook:328
+#: C/index.docbook:277
+#: C/index.docbook:305
 msgid "PNG - Portable Network Graphics"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:302
+#: C/index.docbook:279
 msgid "PNM - Portable Anymap from the PPM Toolkit"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:304
+#: C/index.docbook:281
 msgid "RAS - Sun Raster"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:306
+#: C/index.docbook:283
 msgid "SVG - Scalable Vector Graphics"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:308
+#: C/index.docbook:285
 msgid "TGA - Targa"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:310
+#: C/index.docbook:287
 msgid "TIFF - Tagged Image File Format"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:312
+#: C/index.docbook:289
 msgid "WBMP - Wireless Bitmap"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:314
+#: C/index.docbook:291
 msgid "XBM - X Bitmap"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:316
+#: C/index.docbook:293
 msgid "XPM - X Pixmap"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:320
+#. (itstool) path: section/para
+#: C/index.docbook:297
 msgid "<application>Image Viewer</application> supports the following formats for saving:"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:331
+#. (itstool) path: section/para
+#: C/index.docbook:308
 msgid "<application>Image Viewer</application> may be able to open and save other image formats, depending on your system configuration and other installed software."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:335
+#. (itstool) path: info/title
+#: C/index.docbook:311
 msgid "Image Viewer Features"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:336
+#. (itstool) path: section/para
+#: C/index.docbook:313
 msgid "<application>Image Viewer</application> has a variety of features to help you view your images. You can zoom in and out or view the image full screen. Regardless of your zoom level, <application>Image Viewer</application> uses a low amount of memory. You can also rotate and flip the image you are viewing."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:341
+#. (itstool) path: section/para
+#: C/index.docbook:318
 msgid "The collection view allows the viewing and editing of large image collections. In this view image operations can be applied to all selected images at once."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:345
+#. (itstool) path: section/para
+#: C/index.docbook:322
 msgid "<application>Image Viewer</application> has special support for digital camera pictures and displays EXIF metadata recorded with the image. This feature requires <systemitem class=\"library\">libexif</systemitem> to be installed on your system. All modifications made in JPEG images are lossless. That is, saving rotated and flipped JPEG images will not recompress the image. Beside this all available metadata (like EXIF) will be preserved and updated accordingly."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/index.docbook:357
+#. (itstool) path: info/title
+#: C/index.docbook:333
 msgid "Getting Started"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:358
+#. (itstool) path: section/para
+#: C/index.docbook:335
 msgid "When you start <application>Image Viewer</application>, the following window is displayed:"
 msgstr ""
 
-#. (itstool) path: figure/title
-#: C/index.docbook:360
+#. (itstool) path: info/title
+#: C/index.docbook:336
 msgid "Image Viewer Start Up Window"
 msgstr ""
 
@@ -425,388 +375,388 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/index.docbook:364
+#: C/index.docbook:341
 msgctxt "_"
 msgid "external ref='figures/eom_start_window.png' md5='fc334bd4c4be62cb78b151066e550aa7'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/index.docbook:362
+#: C/index.docbook:339
 msgid "<imageobject> <imagedata fileref=\"figures/eom_start_window.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Shows <application>Image Viewer</application> main window. Contains titlebar, menubar, toolbar, and display area. Menubar contains File, Edit, View, and Help menus.</phrase> </textobject>"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:372
+#. (itstool) path: section/para
+#: C/index.docbook:349
 msgid "The <application>Image Viewer</application> window contains the following elements:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:375
+#: C/index.docbook:352
 msgid "Menubar"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:377
+#: C/index.docbook:354
 msgid "The menus on the menubar contain all the commands that you need to work with images in <application>Image Viewer</application>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:381
+#: C/index.docbook:358
 msgid "Toolbar"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:383
+#: C/index.docbook:360
 msgid "The toolbar contains a subset of the commands that you can access from the menubar. To show or hide the toolbar, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Toolbar</guimenuitem></menuchoice>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:387
+#: C/index.docbook:364
 msgid "Display area"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:389
+#: C/index.docbook:366
 msgid "The display area shows the image file."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:393
+#: C/index.docbook:370
 msgid "Statusbar"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:395
+#: C/index.docbook:372
 msgid "The statusbar provides information about the image. To show or hide the statusbar, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Statusbar</guimenuitem></menuchoice>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:399
+#: C/index.docbook:376
 msgid "Image Collection"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:401
+#: C/index.docbook:378
 msgid "The image collection shows you all supported images in the current working directory. It shows up once an image has been loaded. To show or hide the collection, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Image Collection</guimenuitem></menuchoice> or press <keycap>F9</keycap>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:405
+#: C/index.docbook:382
 msgid "Image Information Pane"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:407
+#: C/index.docbook:384
 msgid "The image information pane provides further information about the current image, for example EXIF metadata (if available). It shows up after an image has been loaded. To show or hide the image information pane, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Image Information</guimenuitem></menuchoice> or press <keycombo><keycap>Ctrl</keycap><keycap>I</keycap></keycombo>."
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:411
+#. (itstool) path: section/para
+#: C/index.docbook:388
 msgid "Most actions in <application>Image Viewer</application> can be performed several ways. For example, you can open a file in the following ways:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:414
+#: C/index.docbook:391
 msgid "Drag an image file into the <application>Image Viewer</application> window from another application or window."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:416
+#: C/index.docbook:393
 msgid "Double-click on an image file in the file manager or other application."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:418
+#: C/index.docbook:395
 msgid "Choose <menuchoice><guimenu>Image</guimenu> <guimenuitem>Open</guimenuitem></menuchoice> and select an image file in the <application>Load Image</application> dialog."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:421
+#: C/index.docbook:398
 msgid "Press <keycombo><keycap>Ctrl</keycap><keycap>O</keycap> </keycombo> and select an image file in the <application>Load Image</application> dialog."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/index.docbook:430
+#. (itstool) path: info/title
+#: C/index.docbook:406
 msgid "Viewing Images"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:434
+#. (itstool) path: info/title
+#: C/index.docbook:410
 msgid "Opening an Image"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:435
+#. (itstool) path: section/para
+#: C/index.docbook:412
 msgid "To open an image, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:438
+#: C/index.docbook:415
 msgid "Choose <menuchoice> <guimenu>Image</guimenu><guimenuitem>Open</guimenuitem> </menuchoice>, or press <keycombo> <keycap>Ctrl</keycap><keycap>O</keycap> </keycombo>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:442
+#: C/index.docbook:419
 msgid "In the <guilabel>Open Image</guilabel> dialog, select the file you want to open."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:447
+#: C/index.docbook:424
 msgid "Click <guibutton>Open</guibutton>. <application>Image Viewer</application> displays the name of the image file in the titlebar of the window."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:452
+#. (itstool) path: section/para
+#: C/index.docbook:429
 msgid "To open another image, choose <menuchoice> <guimenu>Image</guimenu><guimenuitem>Open</guimenuitem> </menuchoice> again. <application>Image Viewer</application> opens each image in a new window."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:459
+#. (itstool) path: info/title
+#: C/index.docbook:435
 msgid "Viewing the Images in a Folder"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:460
+#. (itstool) path: section/para
+#: C/index.docbook:437
 msgid "To view all images in a folder, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:463
+#: C/index.docbook:440
 msgid "Open one of the images in the folder (see <xref linkend=\"eom-open-image\"/>)."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:467
+#: C/index.docbook:444
 msgid "Open the image collection by choosing <menuchoice><guimenu>View</guimenu><guimenuitem>Image Collection</guimenuitem></menuchoice> or pressing <keycap>F9</keycap>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:472
+#. (itstool) path: section/para
+#: C/index.docbook:449
 msgid "The collection shows thumbnails of all supported images in the folder. You can browse the images by clicking on an image in the collection, by choosing the appropriate option in the <guimenu>Go</guimenu> menu or by pressing <keycombo><keycap>Alt</keycap><keycap>Left</keycap></keycombo> or <keycombo><keycap>Alt</keycap><keycap>Right</keycap></keycombo>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:473
+#. (itstool) path: section/para
+#: C/index.docbook:450
 msgid "To view all the directory images in fullscreen, choose <menuchoice> <guimenu>View</guimenu><guimenuitem>Full Screen</guimenuitem> </menuchoice> or press <keycap>F11</keycap>. To view them as a slide show, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Slideshow</guimenuitem></menuchoice> or press <keycap>F5</keycap>. To return to the collection view, press the <keycap>Esc</keycap> key, or <keycombo><keycap>Ctrl</keycap><keycap>W</keycap></keycombo>. For more information about how to customize the slide show, see <xref linkend=\"eom-prefs-slideshow\"/>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:479
+#. (itstool) path: info/title
+#: C/index.docbook:455
 msgid "Scrolling an Image"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:480
+#. (itstool) path: section/para
+#: C/index.docbook:457
 msgid "To scroll around an image that is larger than the image window or full screen view, you can use the following methods:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:482
+#: C/index.docbook:459
 msgid "Use the arrow keys on the keyboard."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:484
+#: C/index.docbook:461
 msgid "Drag the image to move it in the window. (This means you drag the image in the opposite direction you want to scroll in: to scroll down the image, drag it upwards in the window.)"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:486
+#: C/index.docbook:463
 msgid "Use the scrollbars on the window."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:493
+#. (itstool) path: info/title
+#: C/index.docbook:469
 msgid "Zooming"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:494
+#. (itstool) path: section/para
+#: C/index.docbook:471
 msgid "You can zoom in or out of the image in the following ways:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:496
+#: C/index.docbook:473
 msgid "Use the <mousebutton>scroll wheel</mousebutton> on your mouse. Scrolling down zooms out; scrolling up zooms in."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:497
+#: C/index.docbook:474
 msgid "Choose <menuchoice><guimenu>View</guimenu><guimenuitem>Zoom In</guimenuitem></menuchoice> or <menuchoice><guimenu>View</guimenu><guimenuitem>Zoom Out</guimenuitem></menuchoice>. To restore the image to its original size, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Normal Size</guimenuitem></menuchoice>. To make the image fit in the window, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Best Fit</guimenuitem></menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:500
+#: C/index.docbook:477
 msgid "Use the zoom buttons in the toolbar. <guilabel>Normal</guilabel> will restore the picture to its original unscaled size. <guilabel>Fit</guilabel> will resize the image so it will fit in the window if it is too large."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:504
+#: C/index.docbook:481
 msgid "Use the keyboard. To zoom in, <keycombo> <keycap>Ctrl</keycap><keycap>+</keycap> </keycombo> or <keycap>+</keycap>. To zoom out, <keycombo> <keycap>Ctrl</keycap><keycap>-</keycap> </keycombo> or <keycap>-</keycap>. To go back to the normal size, <keycombo> <keycap>Ctrl</keycap><keycap>0</keycap> </keycombo> or <keycap>1</keycap>. To scale the image to fit the window, press <keycap>F</keycap>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:506
+#. (itstool) path: section/para
+#: C/index.docbook:483
 msgid "When an image is zoomed to fit the window, resizing the window will also change the zoom level, so the image still fits the window."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:511
+#. (itstool) path: info/title
+#: C/index.docbook:487
 msgid "Viewing an Image Full Screen/Slideshow"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:512
+#. (itstool) path: section/para
+#: C/index.docbook:489
 msgid "To show the image using the entire screen, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Full Screen</guimenuitem></menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:513
+#. (itstool) path: section/para
+#: C/index.docbook:490
 msgid "No panels, window frames, or menubars are visible when an image is shown like this. To return to the normal view, press <keycap>Esc</keycap>, or <keycap>F11</keycap>, or <keycombo><keycap>Ctrl</keycap><keycap>W</keycap></keycombo>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:514
+#. (itstool) path: section/para
+#: C/index.docbook:491
 msgid "You can zoom or scroll around the image in the same way as when it is shown in a window, using the mouse or the keyboard."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:515
+#. (itstool) path: section/para
+#: C/index.docbook:492
 msgid "If you have multiple images in your collection you can press <keycap>Space</keycap> or use the right/down cursor keys to advance to the next image. The previous image can be reached by pressing <keycap>Backspace</keycap> or using the left/up cursor keys."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:516
+#. (itstool) path: section/para
+#: C/index.docbook:493
 msgid "In this case you can also use the slideshow mode, where <application>Image Viewer</application> automatically switches to the next image in your collection. You can start a slideshow by choosing <menuchoice><guimenu>View</guimenu><guimenuitem>Slideshow</guimenuitem></menuchoice> or by pressing <keycap>F5</keycap>. The slideshow can be paused/continued by pressing <keycap>P</keycap>. To stop the slideshow, press the <keycap>Esc</keycap> or <keycap>F5</keycap> key, or <keycombo><keycap>Ctrl</keycap><keycap>W</keycap></keycombo>. For more information about how to customize the slide show, see <xref linkend=\"eom-prefs-slideshow\"/>."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/index.docbook:523
+#. (itstool) path: info/title
+#: C/index.docbook:499
 msgid "Manipulating Images"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:525
+#. (itstool) path: section/para
+#: C/index.docbook:502
 msgid "All image manipulations apply to all selected images at once. The modifications are done in memory and alter the original files on disk only when the images are saved with the save function (see <xref linkend=\"eom-save-image\"/>)."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:531
+#. (itstool) path: info/title
+#: C/index.docbook:507
 msgid "Flipping an Image"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:532
+#. (itstool) path: section/para
+#: C/index.docbook:509
 msgid "To flip an image along the horizontal axis of the image, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Flip Horizontal</guimenuitem> </menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:537
+#. (itstool) path: section/para
+#: C/index.docbook:514
 msgid "To flip an image along the vertical axis of the image, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Flip Vertical</guimenuitem> </menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:546
+#. (itstool) path: info/title
+#: C/index.docbook:522
 msgid "Rotating an Image"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:547
+#. (itstool) path: section/para
+#: C/index.docbook:524
 msgid "To rotate an image 90 degrees in a clockwise direction, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Rotate Clockwise</guimenuitem> </menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:552
+#. (itstool) path: section/para
+#: C/index.docbook:529
 msgid "To rotate an image 90 degrees in an anticlockwise direction, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Rotate Counterclockwise</guimenuitem> </menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:561
+#. (itstool) path: info/title
+#: C/index.docbook:537
 msgid "Undoing an Action"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:562
+#. (itstool) path: section/para
+#: C/index.docbook:539
 msgid "To undo a flip or rotate action, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Undo</guimenuitem> </menuchoice> or press <keycombo><keycap>Ctrl</keycap><keycap>Z</keycap></keycombo> ."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:573
+#. (itstool) path: info/title
+#: C/index.docbook:549
 msgid "Deleting an Image"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:574
+#. (itstool) path: section/para
+#: C/index.docbook:551
 msgid "To move an image to the Trash, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Move to Trash</guimenuitem> </menuchoice>. This moves the file to the Trash folder. Multiple images can also be moved to the trash in the same way: select them all first."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:580
-msgid "To restore an image from the Trash, open the Trash folder in <application>Caja</application> file manager and move the image file to another folder. To delete the image permanently, empty the Trash. To find out more about using the Trash, see the <ulink type=\"help\" url=\"help:mate-user-guide/caja-trash\">Desktop User Guide</ulink>."
+#. (itstool) path: section/para
+#: C/index.docbook:557
+msgid "To restore an image from the Trash, open the Trash folder in <application>Caja</application> file manager and move the image file to another folder. To delete the image permanently, empty the Trash. To find out more about using the Trash, see the <link xlink:href=\"help:mate-user-guide/caja-trash\">Desktop User Guide</link>."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/index.docbook:582
+#: C/index.docbook:559
 msgid "You can also use the <keycap>Del</keycap> key to move an image to the Trash, in which case you will be asked for confirmation."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/index.docbook:589
+#. (itstool) path: info/title
+#: C/index.docbook:565
 msgid "Saving Images"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:591
+#. (itstool) path: section/para
+#: C/index.docbook:568
 msgid "<application>Image Viewer</application> always tries to choose the save method with the least impact to the image data. For example, if an otherwise unmodified image is saved under a different name in the same format, the file is simply copied. If <systemitem class=\"library\">libjpeg</systemitem> is available on the system all JPEG image modifications are done without loss of image information."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:598
+#. (itstool) path: info/title
+#: C/index.docbook:573
 msgid "Saving an Image"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:599
+#. (itstool) path: section/para
+#: C/index.docbook:575
 msgid "To save an image, choose <menuchoice> <guimenu>Image</guimenu> <guimenuitem>Save</guimenuitem> </menuchoice>. The image will be saved under the same name and file type. Therefore, unmodified images needn't be saved."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:609
+#. (itstool) path: info/title
+#: C/index.docbook:584
 msgid "Saving an Image under a Different Name"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:610
+#. (itstool) path: section/para
+#: C/index.docbook:586
 msgid "To save an image under a different name, or convert it to a different file type, choose <menuchoice> <guimenu>Image</guimenu> <guimenuitem>Save As</guimenuitem> </menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:615
+#. (itstool) path: section/para
+#: C/index.docbook:591
 msgid "Specify the filename in the <guilabel>Name</guilabel> field in the <guilabel>Save Image</guilabel> dialog, then click <guibutton>Save</guibutton>. The file is saved in the current folder by default. <application>Image Viewer</application> tries to determine the file type from the given filename suffix. If the image should be saved in another folder or the file type detection failed, expand the dialog by clicking on <guilabel>Browse for other folders</guilabel>. This allows further folder navigation and the specification of the file type from the drop down box."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:616
+#. (itstool) path: section/para
+#: C/index.docbook:592
 msgid "You can save multiple images at once: see the next section."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:621
+#. (itstool) path: info/title
+#: C/index.docbook:596
 msgid "Saving Multiple Images"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:622
+#. (itstool) path: section/para
+#: C/index.docbook:598
 msgid "Saving multiple images at once allows you to convert several images to a different format, or give them similar filenames."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:623
+#. (itstool) path: section/para
+#: C/index.docbook:599
 msgid "To save multiple images, select the images and choose <menuchoice> <guimenu>Image</guimenu> <guimenuitem>Save As</guimenuitem> </menuchoice>. The following window is displayed:"
 msgstr ""
 
-#. (itstool) path: figure/title
-#: C/index.docbook:630
+#. (itstool) path: info/title
+#: C/index.docbook:605
 msgid "Save As dialog for multiple images"
 msgstr ""
 
@@ -815,158 +765,158 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/index.docbook:634
+#: C/index.docbook:610
 msgctxt "_"
 msgid "external ref='figures/eom_save_as_window.png' md5='fdebb65611d88ced4201754b0f417783'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/index.docbook:632
+#: C/index.docbook:608
 msgid "<imageobject> <imagedata fileref=\"figures/eom_save_as_window.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Shows Eye of MATE <guilabel>Save As</guilabel> dialog when saving multiple images.</phrase> </textobject>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:642
+#. (itstool) path: section/para
+#: C/index.docbook:618
 msgid "The folder in which the images will be saved is specified by the <guilabel>Destination folder</guilabel> drop-down box. Initially the folder is set to the current folder. Select <guilabel>Other...</guilabel> from the drop-down list to open a standard open folder dialog for browsing the filesystem. The resulting filename for each image is specified by <guilabel>Filename format</guilabel>. The filename schema is constructed by simple characters and special tags. The following special tags are available:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:645
+#: C/index.docbook:621
 msgid "<guilabel>Filename (%f)</guilabel> - Original filename without the fileformat suffix."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:647
+#: C/index.docbook:623
 msgid "<guilabel>Counter (%n)</guilabel> - Auto-incremented number (starts at specified counter start)."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:650
+#. (itstool) path: section/para
+#: C/index.docbook:626
 msgid "Everything but these special tags are considered normal text."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:651
+#. (itstool) path: section/para
+#: C/index.docbook:627
 msgid "The image format is determined by the drop-down box after the schema definition. Select a specific image format or use the <guilabel>as is</guilabel> option to state that the same format as the original file should be used."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:654
+#. (itstool) path: section/para
+#: C/index.docbook:630
 msgid "The <guilabel>Options</guilabel> section allows to remove all space characters by underscores in the resulting filename if <guilabel>Replace spaces with underscores</guilabel> is checked. The <guilabel>Start counter at</guilabel> spin box determines at which number the counter starts if you use the %n tag for the file format specification."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:655
+#. (itstool) path: section/para
+#: C/index.docbook:631
 msgid "The <guilabel>File Name Preview</guilabel> section of the dialog shows the resulting file name according to the above settings for an example filename from the selected images."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/index.docbook:664
+#. (itstool) path: info/title
+#: C/index.docbook:639
 msgid "Printing Images"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:666
+#. (itstool) path: info/title
+#: C/index.docbook:641
 msgid "Setting your Page Settings"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:667
+#. (itstool) path: section/para
+#: C/index.docbook:643
 msgid "Before printing you need to set the page settings you would like to use. To do that choose <menuchoice><guimenu>Image</guimenu><guimenuitem>Page Setup</guimenuitem></menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:668
+#. (itstool) path: section/para
+#: C/index.docbook:644
 msgid "In the <guilabel>Page Setup</guilabel> dialog you can now choose paper size and orientation. If possible, configure your printer to have the page borders set correctly."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:672
+#. (itstool) path: info/title
+#: C/index.docbook:647
 msgid "Printing an Image"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:673
+#. (itstool) path: section/para
+#: C/index.docbook:649
 msgid "To print an image, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:676
+#: C/index.docbook:652
 msgid "Select <menuchoice><guimenu>Image</guimenu><guimenuitem>Print</guimenuitem></menuchoice>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:679
+#: C/index.docbook:655
 msgid "In the <guilabel>Print</guilabel> dialog, select the printer you want to use from the list."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:682
+#: C/index.docbook:658
 msgid "Click <guilabel>Print</guilabel>. <application>Image Viewer</application> starts printing now."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:685
+#. (itstool) path: section/para
+#: C/index.docbook:661
 msgid "Images that are too large for the page are automatically scaled down to fit the page. Images that are smaller than the page are centered on it."
 msgstr ""
 
 #. (itstool) path: important/para
-#: C/index.docbook:687
+#: C/index.docbook:663
 msgid "Please note that <application>Image Viewer</application> is currently lacking progress reporting while printing. During that time the user interface might become unresponsive for a short time."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:692
+#. (itstool) path: info/title
+#: C/index.docbook:667
 msgid "Arranging an Image on the Page"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:693
+#. (itstool) path: section/para
+#: C/index.docbook:669
 msgid "Maybe you don't want your image centered or want it scaled down even further. To do that you need to open the <guilabel>Print</guilabel> dialog (see <xref linkend=\"eom-print-image\"/>) and then select the <guilabel>Image Settings</guilabel> tab which offers you the following options:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:696
+#: C/index.docbook:672
 msgid "The options in the <guilabel>Position</guilabel> section allow you to change the images position on the page."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:699
+#: C/index.docbook:675
 msgid "It is also possible to position the image on the page by dragging it around in the <guilabel>Preview</guilabel> field."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:702
+#: C/index.docbook:678
 msgid "The options in the <guilabel>Size</guilabel> section allow you to scale your image to your liking. Scaling is limited by either the image size or by the page size, depending on what condition is met first."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:705
+#: C/index.docbook:681
 msgid "The <guilabel>Unit</guilabel> option allows you to change the metric unit which is used by the options on the <guilabel>Image Settings</guilabel> tab. When you change this option the other fields values are converted accordingly."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/index.docbook:712
+#. (itstool) path: info/title
+#: C/index.docbook:687
 msgid "Personalizing The Toolbar"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:713
+#. (itstool) path: section/para
+#: C/index.docbook:689
 msgid "Image Viewer's default toolbar contains only a basic set of items to keep it simple. But you can modify the toolbar if you prefer a different set."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:715
+#. (itstool) path: info/title
+#: C/index.docbook:690
 msgid "Modifying the Toolbar"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:716
+#. (itstool) path: section/para
+#: C/index.docbook:692
 msgid "If you want to modify the toolbar you need to open the toolbar editor by going to <menuchoice><guimenu>Edit</guimenu><guimenuitem>Toolbar</guimenuitem></menuchoice>. The following window will pop up:"
 msgstr ""
 
-#. (itstool) path: figure/title
-#: C/index.docbook:718
+#. (itstool) path: info/title
+#: C/index.docbook:693
 msgid "The toolbar editor window"
 msgstr ""
 
@@ -975,173 +925,203 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/index.docbook:722
+#: C/index.docbook:698
 msgctxt "_"
 msgid "external ref='figures/eom_toolbar_editor_window.png' md5='b5555dbf7beaf036227fc6e32e974b83'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/index.docbook:720
+#: C/index.docbook:696
 msgid "<imageobject> <imagedata fileref=\"figures/eom_toolbar_editor_window.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Shows Eye of MATE toolbar editor window.</phrase> </textobject>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:730
+#. (itstool) path: section/para
+#: C/index.docbook:706
 msgid "It contains the items that are not in the toolbar and the separator item. You can now edit the toolbar:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:733
+#: C/index.docbook:709
 msgid "To add new items to the toolbar, drag them from the toolbar editor to the toolbar."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:736
+#: C/index.docbook:712
 msgid "To remove items from the toolbar, drag them from the toolbar to the toolbar editor."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:739
+#: C/index.docbook:715
 msgid "To rearrange items on the toolbar, drag them to their new position on the toolbar."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:742
+#. (itstool) path: section/para
+#: C/index.docbook:718
 msgid "When you have finished editing the toolbar, click the <guibutton>Close</guibutton> button in the toolbar editor window. This will close the toolbar editor and make your modified toolbar active."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:745
+#. (itstool) path: info/title
+#: C/index.docbook:720
 msgid "Resetting the Toolbar"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:746
+#. (itstool) path: section/para
+#: C/index.docbook:722
 msgid "To revert your changes to the toolbar and return to the default layout, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:749
+#: C/index.docbook:725
 msgid "Open the toolbar editor (see <xref linkend=\"eom-toolbareditor-use\"/>)."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:752
+#: C/index.docbook:728
 msgid "Click the <guibutton>Reset to Default</guibutton> button."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:755
+#: C/index.docbook:731
 msgid "Click the <guibutton>Close</guibutton> button to close the toolbar editor. The toolbar has been reset to the default layout now."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/index.docbook:761
+#. (itstool) path: info/title
+#: C/index.docbook:736
 msgid "Preferences"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:762
+#. (itstool) path: section/para
+#: C/index.docbook:738
 msgid "Preferences can be changed by going to <menuchoice><guimenu>Edit</guimenu><guimenuitem>Preferences</guimenuitem></menuchoice>. You will be able to change the options for image viewing and slide shows. The changes apply to all open windows instantly."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:766
+#. (itstool) path: info/title
+#: C/index.docbook:741
 msgid "Image View"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:769
+#: C/index.docbook:745
 msgid "<guilabel>Image Enhancements</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:771
+#: C/index.docbook:747
 msgid "Select the <guilabel>Smooth images when zoomed</guilabel> option to enable image smoothing when you change the image's zoom factor. If you select this option, your images will be smoothed to improve their display quality while viewing them with <application>Image Viewer</application>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:772
+#: C/index.docbook:748
 msgid "If you select the <guilabel>Automatic orientation</guilabel> option, your images will be rotated on loading according to their metadata. For example portraits are automatically rotated upright. Note that this function requires a correctly set orientation tag in the image's metadata and thus does not work with all images. The rotation is not saved until you save the rotated image (see <xref linkend=\"eom-save-rename\"/>)."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:777
+#: C/index.docbook:753
 msgid "<guilabel>Transparent Parts</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:779
+#: C/index.docbook:755
 msgid "Select one of the following options to determine how <application>Image Viewer</application> displays transparent parts of an image:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:781
+#: C/index.docbook:757
 msgid "<guilabel>As check pattern</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:782
+#: C/index.docbook:758
 msgid "Displays any transparent parts of the image in a check pattern."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:784
+#: C/index.docbook:760
 msgid "<guilabel>As custom color</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:785
+#: C/index.docbook:761
 msgid "Displays any transparent parts of the image in a solid color that you specify. Click on the color selector button to select a color."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:787
+#: C/index.docbook:763
 msgid "<guimenuitem>As background</guimenuitem>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:788
+#: C/index.docbook:764
 msgid "Displays any transparent parts of the image in the background color of the <application>Image Viewer</application> application."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:798
+#. (itstool) path: info/title
+#: C/index.docbook:773
 msgid "Slideshow"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:801
+#: C/index.docbook:777
 msgid "<guilabel>Image Zoom</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:803
+#: C/index.docbook:779
 msgid "Select the <guilabel>Expand images to fit screen</guilabel> option to enlarge images to fit the screen during the slide show. If you do not select this option, images that are smaller than the screen size are not resized to fit the screen."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:807
+#: C/index.docbook:783
 msgid "<guilabel>Sequence</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:809
+#: C/index.docbook:785
 msgid "Select the <guilabel>Loop sequence</guilabel> option to cycle endlessly through the list of images during the slide show. If you do not select this option, the slide show returns to the collection view after the last image is displayed."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:811
+#: C/index.docbook:787
 msgid "Use the <guilabel>Switch image after ... seconds</guilabel> spin box to specify how long each image is displayed during the slide show. If you set this value to zero, the auto advance function is disabled and only manual browsing is available (see <xref linkend=\"eom-fullscreen\"/>)."
 msgstr ""
 
-#. (itstool) path: para/ulink
-#: C/legal.xml:9
-msgid "link"
+#. (itstool) path: legalnotice/para
+#: C/legal.xml:4
+msgid "Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License (GFDL), Version 1.1 or any later version published by the Free Software Foundation with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts. You can find a copy of the GFDL at this <link xlink:href=\"https://www.gnu.org/licenses/fdl-1.1.html\">link</link> or in the file COPYING-DOCS distributed with this manual."
 msgstr ""
 
 #. (itstool) path: legalnotice/para
-#: C/legal.xml:2
-msgid "Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License (GFDL), Version 1.1 or any later version published by the Free Software Foundation with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts. You can find a copy of the GFDL at this <_:ulink-1/> or in the file COPYING-DOCS distributed with this manual."
+#: C/legal.xml:13
+msgid "This manual is part of a collection of MATE manuals distributed under the GFDL. If you want to distribute this manual separately from the collection, you can do so by adding a copy of the license to the manual, as described in section 6 of the license."
+msgstr ""
+
+#. (itstool) path: legalnotice/para
+#: C/legal.xml:20
+msgid "Many of the names used by companies to distinguish their products and services are claimed as trademarks. Where those names appear in any MATE documentation, and the members of the MATE Documentation Project are made aware of those trademarks, then the names are in capital letters or initial capital letters."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/legal.xml:36
+msgid "DOCUMENT IS PROVIDED ON AN \"AS IS\" BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, WITHOUT LIMITATION, WARRANTIES THAT THE DOCUMENT OR MODIFIED VERSION OF THE DOCUMENT IS FREE OF DEFECTS MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY, ACCURACY, AND PERFORMANCE OF THE DOCUMENT OR MODIFIED VERSION OF THE DOCUMENT IS WITH YOU. SHOULD ANY DOCUMENT OR MODIFIED VERSION PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE INITIAL WRITER, AUTHOR OR ANY CONTRIBUTOR) ASSUME THE COST OF ANY NECESSARY SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE OF ANY DOCUMENT OR MODIFIED VERSION OF THE DOCUMENT IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS DISCLAIMER; AND"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/legal.xml:56
+msgid "UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER IN TORT (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL THE AUTHOR, INITIAL WRITER, ANY CONTRIBUTOR, OR ANY DISTRIBUTOR OF THE DOCUMENT OR MODIFIED VERSION OF THE DOCUMENT, OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE LIABLE TO ANY PERSON FOR ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF GOODWILL, WORK STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER DAMAGES OR LOSSES ARISING OUT OF OR RELATING TO USE OF THE DOCUMENT AND MODIFIED VERSIONS OF THE DOCUMENT, EVEN IF SUCH PARTY SHALL HAVE BEEN INFORMED OF THE POSSIBILITY OF SUCH DAMAGES."
+msgstr ""
+
+#. (itstool) path: legalnotice/para
+#: C/legal.xml:29
+msgid "DOCUMENT AND MODIFIED VERSIONS OF THE DOCUMENT ARE PROVIDED UNDER THE TERMS OF THE GNU FREE DOCUMENTATION LICENSE WITH THE FURTHER UNDERSTANDING THAT: <_:orderedlist-1/>"
+msgstr ""
+
+#. (itstool) path: formalpara/title
+#: C/legal.xml:77
+msgid "Feedback"
+msgstr ""
+
+#. (itstool) path: formalpara/para
+#: C/legal.xml:78
+msgid "To report a bug or make a suggestion regarding the <application>Image Viewer</application> application or this manual, follow the directions in the <link xlink:href=\"help:mate-user-guide/feedback\">MATE Feedback Page</link>."
 msgstr ""
 

--- a/help/eom.pot
+++ b/help/eom.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MATE Desktop Environment\n"
-"POT-Creation-Date: 2019-02-07 10:05+0100\n"
+"POT-Creation-Date: 2019-03-09 23:54+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 
 #. (itstool) path: info/copyright
 #: C/index.docbook:20
-msgid "<year>2015</year> <holder>MATE Documentation Project</holder>"
+msgid "<year>2019</year> <holder>MATE Documentation Project</holder>"
 msgstr ""
 
 #. (itstool) path: info/copyright
@@ -183,7 +183,7 @@ msgstr ""
 
 #. (itstool) path: info/releaseinfo
 #: C/index.docbook:217
-msgid "This manual describes version 1.10.2 of Image Viewer."
+msgid "This manual describes version 1.22 of Image Viewer."
 msgstr ""
 
 #. (itstool) path: article/indexterm


### PR DESCRIPTION
To upgrade the manual:
sudo dnf install -y docbook5-schemas
xsltproc --output index-new.docbook /usr/share/xml/docbook5/stylesheet/upgrade/db4-upgrade.xsl index.docbook
xsltproc --output legal-new.xml /usr/share/xml/docbook5/stylesheet/upgrade/db4-upgrade.xsl legal.xml

To validate the manual:
xmllint --noout --relaxng /usr/share/xml/docbook5/schema/rng/5.0/docbook.rng help/C/index.docbook
jing /usr/share/xml/docbook5/schema/rng/5.0/docbook.rng help/C/index.docbook
yelp-check validate help/C/index.docbook

To view the manual:
yelp file:///full_path/index.docbook

Note: docbook5-schemas should be installed in your system in order to view the manual (DEPENDENCY)