### PR TITLE
Use persistent page setup

### DIFF
--- a/src/eom-window.c
+++ b/src/eom-window.c
@@ -2176,10 +2176,10 @@ eom_window_print (EomWindow *window)
 	/* Make sure the window stays valid while printing */
 	g_object_ref (window);
 
-	if (window->priv->page_setup !=NULL)
+	if (window->priv->page_setup != NULL)
 		page_setup = g_object_ref (window->priv->page_setup);
 	else
-		page_setup = NULL;
+		page_setup = eom_print_get_page_setup ();
 
 	print = eom_print_operation_new (window->priv->image,
 					 print_settings,
@@ -2213,6 +2213,7 @@ eom_window_print (EomWindow *window)
 		if (window->priv->page_setup != NULL)
 			g_object_unref (window->priv->page_setup);
 		window->priv->page_setup = g_object_ref (new_page_setup);
+		eom_print_set_page_setup (window->priv->page_setup);
 	}
 
 	if (page_setup != NULL)


### PR DESCRIPTION
When changing page settings on the print dialog, the new settings should persist across sessions of eom.

To test this:
1. Open the Print dialog
2. Select a different Page Size (US Letter, A4, etc.)
3. Print the file (into a PDF is fine too, no need to waste paper :wink:)
4. Close eom
5. Go back to step 1 and see which Page Size is selected by default

Without this patch, the last-used Page Size is not remembered. With this patch, the last-used Page Size should be automatically selected.

Fixes #206 