### PR TITLE
store: Add any image file in the current directory to the store

### DIFF
--- a/data/eom.desktop.in.in
+++ b/data/eom.desktop.in.in
@@ -14,4 +14,4 @@ X-MATE-Bugzilla-Product=EOM
 X-MATE-Bugzilla-Component=general
 X-MATE-Bugzilla-Version=@VERSION@
 X-MATE-DocPath=eom/index.docbook
-MimeType=image/bmp;image/gif;image/jpeg;image/jpg;image/pjpeg;image/png;image/tiff;image/x-bmp;image/x-gray;image/x-icb;image/x-ico;image/x-png;image/x-portable-anymap;image/x-portable-bitmap;image/x-portable-graymap;image/x-portable-pixmap;image/x-xbitmap;image/x-xpixmap;image/x-pcx;image/svg+xml;image/svg+xml-compressed;image/vnd.wap.wbmp;
+MimeType=image/*;

--- a/src/eom-list-store.c
+++ b/src/eom-list-store.c
@@ -475,8 +475,9 @@ directory_visit (GFile *directory,
 	mime_type = g_file_info_get_content_type (children_info);
 	name = g_file_info_get_name (children_info);
 
-        if (!g_str_has_prefix (name, ".")) {
-		if (eom_image_is_supported_mime_type (mime_type)) {
+	if (!g_str_has_prefix (name, ".")) {
+		/* We support opening any image type, so let eom to add any images in the current directory to the store */
+		if (g_content_type_is_mime_type (mime_type, "image/*") || eom_image_is_supported_mime_type (mime_type)) {
 			load_uri = TRUE;
 		}
 	}


### PR DESCRIPTION
This allows eom to navigate through all image files in a directory without having to manually load them into the store.

Fixes #218 