### PR TITLE
Open with menu leaks

### DIFF
--- a/src/eom-window.c
+++ b/src/eom-window.c
@@ -945,6 +945,7 @@ eom_window_update_openwith_menu (EomWindow *window, EomImage *image)
 
 	if (priv->actions_open_with != NULL) {
 		gtk_ui_manager_remove_action_group (priv->ui_mgr, priv->actions_open_with);
+		g_object_unref (priv->actions_open_with);
 		priv->actions_open_with = NULL;
 	}
 

--- a/src/eom-window.c
+++ b/src/eom-window.c
@@ -219,6 +219,10 @@ static void eom_window_list_store_image_removed (GtkTreeModel *tree_model,
 						 gpointer      user_data);
 static void eom_window_set_wallpaper (EomWindow *window, const gchar *filename, const gchar *visible_filename);
 static gboolean eom_window_save_images (EomWindow *window, GList *images);
+static void disconnect_proxy_cb (GtkUIManager *manager,
+                                 GtkAction *action,
+                                 GtkWidget *proxy,
+                                 EomWindow *window);
 static void eom_window_finish_saving (EomWindow *window);
 static GAppInfo *get_appinfo_for_editor (EomWindow *window);
 
@@ -3882,6 +3886,7 @@ connect_proxy_cb (GtkUIManager *manager,
                   EomWindow *window)
 {
 	if (GTK_IS_MENU_ITEM (proxy)) {
+		disconnect_proxy_cb (manager, action, proxy, window);
 		g_signal_connect (proxy, "select",
 				  G_CALLBACK (menu_item_select_cb), window);
 		g_signal_connect (proxy, "deselect",


### PR DESCRIPTION
This should fix two memory leaks related to the "Open with" menu.

7bfca3a: The GAppInfos created by g_app_info_get_all_for_type() in eom_window_update_openwith_menu() aren't freed

2efa136: connect_proxy_cb() can be called repeatedly for the same menu items, resulting in lots of redundant GClosures hanging around

This should help with #139, but it won't completely fix it.