### PR TITLE
Restore image types list and add wildcard

### DIFF
--- a/data/eom.desktop.in.in
+++ b/data/eom.desktop.in.in
@@ -14,4 +14,4 @@ X-MATE-Bugzilla-Product=EOM
 X-MATE-Bugzilla-Component=general
 X-MATE-Bugzilla-Version=@VERSION@
 X-MATE-DocPath=eom/index.docbook
-MimeType=image/*;
+MimeType=image/bmp;image/gif;image/jpeg;image/jpg;image/pjpeg;image/png;image/tiff;image/x-bmp;image/x-gray;image/x-icb;image/x-ico;image/x-png;image/x-portable-anymap;image/x-portable-bitmap;image/x-portable-graymap;image/x-portable-pixmap;image/x-xbitmap;image/x-xpixmap;image/x-pcx;image/svg+xml;image/svg+xml-compressed;image/vnd.wap.wbmp;image/x-icns;image/*;


### PR DESCRIPTION
I restored the image list from [Eye of GNOME](https://gitlab.gnome.org/GNOME/eog/blob/master/data/eog.desktop.in.in) and added the `image/*` wildcard at the end.

Partially fixes https://github.com/mate-desktop/mate-control-center/issues/443