### PR TITLE
Suppress GtkAction deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -187,6 +187,8 @@ before_scripts:
   - if [ ${DISTRO_NAME} == "debian" ];then
   -     curl -Ls -o debian.sh https://github.com/mate-desktop/mate-dev-scripts/raw/master/travis/debian.sh
   -     bash ./debian.sh
+  -     egrep -lRZ 'G_GNUC_BEGIN_IGNORE_DEPRECATIONS' . | xargs -0 -l sed -i -e 's/G_GNUC_BEGIN_IGNORE_DEPRECATIONS/ /g'
+  -     egrep -lRZ 'G_GNUC_END_IGNORE_DEPRECATIONS' . | xargs -0 -l sed -i -e 's/G_GNUC_END_IGNORE_DEPRECATIONS/ /g'
   - fi
 
 build_scripts:

--- a/cut-n-paste/toolbar-editor/egg-editable-toolbar.c
+++ b/cut-n-paste/toolbar-editor/egg-editable-toolbar.c
@@ -161,11 +161,13 @@ find_action (EggEditableToolbar *etoolbar,
 
   for (; l != NULL; l = l->next)
     {
+      G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
       GtkAction *tmp;
 
       tmp = gtk_action_group_get_action (GTK_ACTION_GROUP (l->data), name);
       if (tmp)
-	action = tmp;
+        action = tmp;
+      G_GNUC_END_IGNORE_DEPRECATIONS;
     }
 
   return action;
@@ -196,22 +198,27 @@ drag_begin_cb (GtkWidget          *widget,
 	       EggEditableToolbar *etoolbar)
 {
   GtkAction *action;
+  const gchar *action_name;
   gint flags;
 
   gtk_widget_hide (widget);
 
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
   action = gtk_activatable_get_related_action (GTK_ACTIVATABLE (widget));
 
   if (action == NULL) return;
 
+  action_name = gtk_action_get_name (action);
+  G_GNUC_END_IGNORE_DEPRECATIONS;
+
   flags = egg_toolbars_model_get_name_flags (etoolbar->priv->model,
-					     gtk_action_get_name (action));
+                                             action_name);
   if (!(flags & EGG_TB_MODEL_NAME_INFINITE))
     {
       flags &= ~EGG_TB_MODEL_NAME_USED;
       egg_toolbars_model_set_name_flags (etoolbar->priv->model,
-					 gtk_action_get_name (action),
-					 flags);
+                                         action_name,
+                                         flags);
     }
 }
 
@@ -221,25 +228,30 @@ drag_end_cb (GtkWidget          *widget,
 	     EggEditableToolbar *etoolbar)
 {
   GtkAction *action;
+  const gchar *action_name;
   gint flags;
 
   if (gtk_widget_get_parent (widget) != NULL)
     {
       gtk_widget_show (widget);
 
+      G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
       action = gtk_activatable_get_related_action (GTK_ACTIVATABLE (widget));
 
       if (action == NULL) return;
 
+      action_name = gtk_action_get_name (action);
+      G_GNUC_END_IGNORE_DEPRECATIONS;
+
       flags = egg_toolbars_model_get_name_flags (etoolbar->priv->model,
-						 gtk_action_get_name (action));
+                                                 action_name);
       if (!(flags & EGG_TB_MODEL_NAME_INFINITE))
         {
-	  flags |= EGG_TB_MODEL_NAME_USED;
-	  egg_toolbars_model_set_name_flags (etoolbar->priv->model,
-					     gtk_action_get_name (action),
-					     flags);
-	}
+          flags |= EGG_TB_MODEL_NAME_USED;
+          egg_toolbars_model_set_name_flags (etoolbar->priv->model,
+                                             action_name,
+                                             flags);
+        }
     }
 }
 
@@ -504,7 +516,9 @@ configure_item_tooltip (GtkToolItem *item)
 {
   GtkAction *action;
 
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
   action = gtk_activatable_get_related_action (GTK_ACTIVATABLE (item));
+  G_GNUC_END_IGNORE_DEPRECATIONS;
 
   if (action != NULL)
     {
@@ -583,6 +597,7 @@ create_item_from_action (EggEditableToolbar *etoolbar,
       GtkAction *action = find_action (etoolbar, name);
       if (action == NULL) return NULL;
 
+      G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
       item = GTK_TOOL_ITEM (gtk_action_create_tool_item (action));
 
       /* Normally done on-demand by the GtkUIManager, but no
@@ -590,6 +605,7 @@ create_item_from_action (EggEditableToolbar *etoolbar,
        */
       gtk_action_set_accel_group
         (action, gtk_ui_manager_get_accel_group(etoolbar->priv->manager));
+      G_GNUC_END_IGNORE_DEPRECATIONS;
 
       g_signal_connect_object (action, "notify::sensitive",
                                G_CALLBACK (action_sensitive_cb), item, 0);
@@ -803,7 +819,9 @@ toggled_visibility_cb (GtkToggleAction *action,
   gboolean visible;
   gint i;
 
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
   visible = gtk_toggle_action_get_active (action);
+  G_GNUC_END_IGNORE_DEPRECATIONS;
   for (i = 0; i < priv->visibility_actions->len; i++)
     if (g_ptr_array_index (priv->visibility_actions, i) == action)
       break;
@@ -934,24 +952,30 @@ toolbar_visibility_refresh (EggEditableToolbar *etoolbar)
 
       if (i >= priv->visibility_actions->len)
         {
-	  action = gtk_toggle_action_new (action_name, action_label, NULL, NULL);
-	  g_ptr_array_add (priv->visibility_actions, action);
-	  g_signal_connect_object (action, "toggled",
-				   G_CALLBACK (toggled_visibility_cb),
-				   etoolbar, 0);
-	  gtk_action_group_add_action (priv->actions, GTK_ACTION (action));
-	}
+          G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
+          action = gtk_toggle_action_new (action_name, action_label, NULL, NULL);
+          G_GNUC_END_IGNORE_DEPRECATIONS;
+          g_ptr_array_add (priv->visibility_actions, action);
+          g_signal_connect_object (action, "toggled",
+                                   G_CALLBACK (toggled_visibility_cb),
+                                   etoolbar, 0);
+          G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
+          gtk_action_group_add_action (priv->actions, GTK_ACTION (action));
+          G_GNUC_END_IGNORE_DEPRECATIONS;          
+        }
       else
         {
 	  action = g_ptr_array_index (priv->visibility_actions, i);
 	  g_object_set (action, "label", action_label, NULL);
         }
 
+      G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
       gtk_action_set_visible (GTK_ACTION (action), (egg_toolbars_model_get_flags (priv->model, i)
-						    & EGG_TB_MODEL_NOT_REMOVABLE) == 0);
+                                                    & EGG_TB_MODEL_NOT_REMOVABLE) == 0);
       gtk_action_set_sensitive (GTK_ACTION (action), showing);
       gtk_toggle_action_set_active (action, gtk_widget_get_visible
-				    (get_dock_nth (etoolbar, i)));
+                                    (get_dock_nth (etoolbar, i)));
+      G_GNUC_END_IGNORE_DEPRECATIONS;
 
       for (list = priv->visibility_paths; list != NULL; list = g_list_next (list))
         {
@@ -969,7 +993,9 @@ toolbar_visibility_refresh (EggEditableToolbar *etoolbar)
     {
       action = g_ptr_array_index (priv->visibility_actions, i);
       g_ptr_array_remove_index_fast (priv->visibility_actions, i);
+      G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
       gtk_action_group_remove_action (priv->actions, GTK_ACTION (action));
+      G_GNUC_END_IGNORE_DEPRECATIONS;
       i++;
     }
 }
@@ -1403,10 +1429,12 @@ egg_editable_toolbar_set_ui_manager (EggEditableToolbar *etoolbar,
 
   etoolbar->priv->manager = g_object_ref (manager);
 
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
   etoolbar->priv->actions = gtk_action_group_new ("ToolbarActions");
   gtk_action_group_set_translation_domain (etoolbar->priv->actions, GETTEXT_PACKAGE);
   gtk_action_group_add_actions (etoolbar->priv->actions, actions,
 		 		G_N_ELEMENTS (actions), etoolbar);
+  G_GNUC_END_IGNORE_DEPRECATIONS;
   gtk_ui_manager_insert_action_group (manager, etoolbar->priv->actions, -1);
   g_object_unref (etoolbar->priv->actions);
 
@@ -1440,9 +1468,11 @@ egg_editable_toolbar_set_selected (EggEditableToolbar *etoolbar,
       editable = FALSE;
     }
 
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
   gtk_action_set_visible (find_action (etoolbar, "RemoveToolbar"), (toolbar != NULL) && (etoolbar->priv->edit_mode > 0));
   gtk_action_set_visible (find_action (etoolbar, "RemoveToolItem"), (toolitem != NULL) && editable);
   gtk_action_set_visible (find_action (etoolbar, "MoveToolItem"), (toolitem != NULL) && editable);
+  G_GNUC_END_IGNORE_DEPRECATIONS;
 }
 
 static void

--- a/cut-n-paste/toolbar-editor/egg-toolbar-editor.c
+++ b/cut-n-paste/toolbar-editor/egg-toolbar-editor.c
@@ -104,7 +104,9 @@ find_action (EggToolbarEditor *t,
     {
       GtkAction *tmp;
 
+      G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
       tmp = gtk_action_group_get_action (GTK_ACTION_GROUP (l->data), name);
+      G_GNUC_END_IGNORE_DEPRECATIONS;
       if (tmp)
 	action = tmp;
     }

--- a/plugins/reload/eom-reload-plugin.c
+++ b/plugins/reload/eom-reload-plugin.c
@@ -116,12 +116,14 @@ eom_reload_plugin_activate (EomWindowActivatable *activatable)
 
 	manager = eom_window_get_ui_manager (plugin->window);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	plugin->ui_action_group = gtk_action_group_new ("EomReloadPluginActions");
 
 	gtk_action_group_set_translation_domain (plugin->ui_action_group, GETTEXT_PACKAGE);
 
 	gtk_action_group_add_actions (plugin->ui_action_group, action_entries,
 	                              G_N_ELEMENTS (action_entries), plugin->window);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	gtk_ui_manager_insert_action_group (manager, plugin->ui_action_group, -1);
 

--- a/src/eom-properties-dialog.c
+++ b/src/eom-properties-dialog.c
@@ -813,6 +813,7 @@ eom_properties_dialog_new (GtkWindow    *parent,
 
 	g_return_val_if_fail (GTK_IS_WINDOW (parent), NULL);
 	g_return_val_if_fail (EOM_IS_THUMB_VIEW (thumbview), NULL);
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	g_return_val_if_fail (GTK_IS_ACTION (next_image_action), NULL);
 	g_return_val_if_fail (GTK_IS_ACTION (previous_image_action), NULL);
 
@@ -827,6 +828,7 @@ eom_properties_dialog_new (GtkWindow    *parent,
 	gtk_activatable_set_related_action (GTK_ACTIVATABLE (EOM_PROPERTIES_DIALOG (prop_dlg)->priv->next_button), next_image_action);
 
 	gtk_activatable_set_related_action (GTK_ACTIVATABLE (EOM_PROPERTIES_DIALOG (prop_dlg)->priv->previous_button), previous_image_action);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	return GTK_WIDGET (prop_dlg);
 }

--- a/src/eom-window.c
+++ b/src/eom-window.c
@@ -356,6 +356,7 @@ eom_window_can_save_changed_cb (GSettings *settings, gchar *key, gpointer user_d
 
 	priv->save_disabled = save_disabled;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action_save =
 		gtk_action_group_get_action (priv->actions_image, "ImageSave");
 	action_save_as =
@@ -374,6 +375,7 @@ eom_window_can_save_changed_cb (GSettings *settings, gchar *key, gpointer user_d
 			gtk_action_set_sensitive (action_save_as, TRUE);
 		}
 	}
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 }
 
 #ifdef HAVE_LCMS
@@ -577,6 +579,7 @@ update_action_groups_state (EomWindow *window)
 
 	priv = window->priv;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action_collection =
 		gtk_action_group_get_action (priv->actions_window,
 					     "ViewImageCollection");
@@ -596,6 +599,7 @@ update_action_groups_state (EomWindow *window)
 	action_print =
 		gtk_action_group_get_action (priv->actions_image,
 					     "ImagePrint");
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	g_assert (action_collection != NULL);
 	g_assert (action_sidebar != NULL);
@@ -610,12 +614,14 @@ update_action_groups_state (EomWindow *window)
 	if (n_images == 0) {
 		gtk_widget_hide (priv->layout);
 
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 		gtk_action_group_set_sensitive (priv->actions_window,      TRUE);
 		gtk_action_group_set_sensitive (priv->actions_image,       FALSE);
 		gtk_action_group_set_sensitive (priv->actions_collection,  FALSE);
 
 		gtk_action_set_sensitive (action_fscreen, FALSE);
 		gtk_action_set_sensitive (action_sshow,   FALSE);
+		G_GNUC_END_IGNORE_DEPRECATIONS;
 
 		/* If there are no images on model, initialization
  		   stops here. */
@@ -641,6 +647,7 @@ update_action_groups_state (EomWindow *window)
 		if (show_image_collection)
 			gtk_widget_show (priv->nav);
 
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 		gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action_collection),
 					      show_image_collection);
 
@@ -657,6 +664,7 @@ update_action_groups_state (EomWindow *window)
 			gtk_action_group_set_sensitive (priv->actions_collection,  TRUE);
 			gtk_action_set_sensitive (action_sshow, TRUE);
 		}
+		G_GNUC_END_IGNORE_DEPRECATIONS;
 
 		if (show_image_collection)
 			gtk_widget_grab_focus (priv->thumbview);
@@ -668,11 +676,13 @@ update_action_groups_state (EomWindow *window)
 						EOM_CONF_LOCKDOWN_CAN_PRINT);
 
 	if (print_disabled) {
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 		gtk_action_set_sensitive (action_print, FALSE);
 	}
 
 	if (eom_sidebar_is_empty (EOM_SIDEBAR (priv->sidebar))) {
 		gtk_action_set_sensitive (action_sidebar, FALSE);
+		G_GNUC_END_IGNORE_DEPRECATIONS;
 		gtk_widget_hide (priv->sidebar);
 	}
 }
@@ -688,6 +698,7 @@ update_selection_ui_visibility (EomWindow *window)
 
 	n_selected = eom_thumb_view_get_n_selected (EOM_THUMB_VIEW (priv->thumbview));
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	wallpaper_action =
 		gtk_action_group_get_action (priv->actions_image,
 					     "ImageSetAsWallpaper");
@@ -697,6 +708,7 @@ update_selection_ui_visibility (EomWindow *window)
 	} else {
 		gtk_action_set_sensitive (wallpaper_action, FALSE);
 	}
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 }
 
 static gboolean
@@ -968,7 +980,9 @@ eom_window_update_openwith_menu (EomWindow *window, EomImage *image)
 	if (!apps)
 		return;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	priv->actions_open_with = gtk_action_group_new ("OpenWithActions");
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	gtk_ui_manager_insert_action_group (priv->ui_mgr, priv->actions_open_with, -1);
 
 	priv->open_with_menu_id = gtk_ui_manager_new_merge_id (priv->ui_mgr);
@@ -993,12 +1007,16 @@ eom_window_update_openwith_menu (EomWindow *window, EomImage *image)
 		label = g_strdup (g_app_info_get_name (app));
 		tip = g_strdup_printf (_("Use \"%s\" to open the selected image"), g_app_info_get_name (app));
 
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 		action = gtk_action_new (name, label, tip, NULL);
+		G_GNUC_END_IGNORE_DEPRECATIONS;
 
 		app_icon = g_app_info_get_icon (app);
 		if (G_LIKELY (app_icon != NULL)) {
 			g_object_ref (app_icon);
+			G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 			gtk_action_set_gicon (action, app_icon);
+			G_GNUC_END_IGNORE_DEPRECATIONS;
 			g_object_unref (app_icon);
 		}
 
@@ -1013,7 +1031,9 @@ eom_window_update_openwith_menu (EomWindow *window, EomImage *image)
 				          G_CALLBACK (open_with_launch_application_cb),
 				          image);
 
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 		gtk_action_group_add_action (priv->actions_open_with, action);
+		G_GNUC_END_IGNORE_DEPRECATIONS;
 		g_object_unref (action);
 
 		gtk_ui_manager_add_ui (priv->ui_mgr,
@@ -1069,11 +1089,13 @@ eom_window_update_openwith_menu (EomWindow *window, EomImage *image)
 
 	g_list_free (apps);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (window->priv->actions_image,
 		                                  "OpenEditor");
 	if (action != NULL) {
 		gtk_action_set_sensitive (action, edit_button_active);
 	}
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 }
 
 static void
@@ -1299,7 +1321,9 @@ eom_job_load_cb (EomJobLoad *job, gpointer data)
 						 priv->display_profile);
 #endif
 
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 		gtk_action_group_set_sensitive (priv->actions_image, TRUE);
+		G_GNUC_END_IGNORE_DEPRECATIONS;
 
 		eom_window_display_image (window, job->image);
 	} else {
@@ -1335,7 +1359,9 @@ eom_job_load_cb (EomJobLoad *job, gpointer data)
 			g_signal_emit (window, signals[SIGNAL_PREPARED], 0);
 		}
 
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 		gtk_action_group_set_sensitive (priv->actions_image, FALSE);
+		G_GNUC_END_IGNORE_DEPRECATIONS;
 	}
 
 	eom_window_clear_load_job (window);
@@ -1349,6 +1375,7 @@ eom_job_load_cb (EomJobLoad *job, gpointer data)
 			 window);
 	}
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action_save = gtk_action_group_get_action (priv->actions_image, "ImageSave");
 	action_undo = gtk_action_group_get_action (priv->actions_image, "EditUndo");
 
@@ -1356,6 +1383,7 @@ eom_job_load_cb (EomJobLoad *job, gpointer data)
 	 * Respect lockdown in case of Save.*/
 	gtk_action_set_sensitive (action_save, (!priv->save_disabled && eom_image_is_modified (job->image)));
 	gtk_action_set_sensitive (action_undo, eom_image_is_modified (job->image));
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	g_object_unref (job->image);
 }
@@ -1390,6 +1418,7 @@ eom_job_transform_cb (EomJobTransform *job, gpointer data)
 
 	eom_window_clear_transform_job (window);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action_undo =
 		gtk_action_group_get_action (window->priv->actions_image, "EditUndo");
 	action_save =
@@ -1403,6 +1432,7 @@ eom_job_transform_cb (EomJobTransform *job, gpointer data)
 	{
 		gtk_action_set_sensitive (action_save, eom_image_is_modified (image));
 	}
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 }
 
 static void
@@ -1530,6 +1560,7 @@ view_zoom_changed_cb (GtkWidget *widget, double zoom, gpointer user_data)
 
 	update_status_bar (window);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action_zoom_in =
 		gtk_action_group_get_action (window->priv->actions_image,
 					     "ViewZoomIn");
@@ -1542,6 +1573,7 @@ view_zoom_changed_cb (GtkWidget *widget, double zoom, gpointer user_data)
 			!eom_scroll_view_get_zoom_is_max (EOM_SCROLL_VIEW (window->priv->view)));
 	gtk_action_set_sensitive (action_zoom_out,
 			!eom_scroll_view_get_zoom_is_min (EOM_SCROLL_VIEW (window->priv->view)));
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 }
 
 static void
@@ -1595,6 +1627,7 @@ eom_window_update_fullscreen_action (EomWindow *window)
 {
 	GtkAction *action;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (window->priv->actions_image,
 					      "ViewFullscreen");
 
@@ -1603,6 +1636,7 @@ eom_window_update_fullscreen_action (EomWindow *window)
 
 	gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action),
 				      window->priv->mode == EOM_WINDOW_MODE_FULLSCREEN);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	g_signal_handlers_unblock_by_func
 		(action, G_CALLBACK (eom_window_cmd_fullscreen), window);
@@ -1613,6 +1647,7 @@ eom_window_update_slideshow_action (EomWindow *window)
 {
 	GtkAction *action;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (window->priv->actions_collection,
 					      "ViewSlideshow");
 
@@ -1621,6 +1656,7 @@ eom_window_update_slideshow_action (EomWindow *window)
 
 	gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action),
 				      window->priv->mode == EOM_WINDOW_MODE_SLIDESHOW);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	g_signal_handlers_unblock_by_func
 		(action, G_CALLBACK (eom_window_cmd_slideshow), window);
@@ -1631,6 +1667,7 @@ eom_window_update_pause_slideshow_action (EomWindow *window)
 {
 	GtkAction *action;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (window->priv->actions_image,
 					      "PauseSlideshow");
 
@@ -1639,6 +1676,7 @@ eom_window_update_pause_slideshow_action (EomWindow *window)
 
 	gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action),
 				      window->priv->mode != EOM_WINDOW_MODE_SLIDESHOW);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	g_signal_handlers_unblock_by_func
 		(action, G_CALLBACK (eom_window_cmd_pause_slideshow), window);
@@ -1845,6 +1883,7 @@ exit_fullscreen_button_clicked_cb (GtkWidget *button, EomWindow *window)
 
 	eom_debug (DEBUG_WINDOW);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	if (window->priv->mode == EOM_WINDOW_MODE_SLIDESHOW) {
 		action = gtk_action_group_get_action (window->priv->actions_collection,
 						      "ViewSlideshow");
@@ -1855,6 +1894,7 @@ exit_fullscreen_button_clicked_cb (GtkWidget *button, EomWindow *window)
 	g_return_if_fail (action != NULL);
 
 	gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action), FALSE);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 }
 
 static GtkWidget *
@@ -1942,7 +1982,9 @@ update_ui_visibility (EomWindow *window)
 
 	action = gtk_ui_manager_get_action (priv->ui_mgr, "/MainMenu/View/ToolbarToggle");
 	g_assert (action != NULL);
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action), visible);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	g_object_set (G_OBJECT (priv->toolbar), "visible", visible, NULL);
 
 	visible = g_settings_get_boolean (priv->ui_settings, EOM_CONF_UI_STATUSBAR);
@@ -1950,7 +1992,9 @@ update_ui_visibility (EomWindow *window)
 
 	action = gtk_ui_manager_get_action (priv->ui_mgr, "/MainMenu/View/StatusbarToggle");
 	g_assert (action != NULL);
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action), visible);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	g_object_set (G_OBJECT (priv->statusbar), "visible", visible, NULL);
 
 	if (priv->status != EOM_WINDOW_STATUS_INIT) {
@@ -1958,7 +2002,9 @@ update_ui_visibility (EomWindow *window)
 		visible = visible && priv->mode != EOM_WINDOW_MODE_SLIDESHOW;
 		action = gtk_ui_manager_get_action (priv->ui_mgr, "/MainMenu/View/ImageCollectionToggle");
 		g_assert (action != NULL);
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 		gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action), visible);
+		G_GNUC_END_IGNORE_DEPRECATIONS;
 		if (visible) {
 			gtk_widget_show (priv->nav);
 		} else {
@@ -1970,7 +2016,9 @@ update_ui_visibility (EomWindow *window)
 	visible = visible && !fullscreen_mode;
 	action = gtk_ui_manager_get_action (priv->ui_mgr, "/MainMenu/View/SidebarToggle");
 	g_assert (action != NULL);
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action), visible);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	if (visible) {
 		gtk_widget_show (priv->sidebar);
 	} else {
@@ -2612,6 +2660,7 @@ eom_window_cmd_show_hide_bar (GtkAction *action, gpointer user_data)
 	EomWindow *window;
 	EomWindowPrivate *priv;
 	gboolean visible;
+	const gchar *action_name;
 
 	g_return_if_fail (EOM_IS_WINDOW (user_data));
 
@@ -2621,21 +2670,24 @@ eom_window_cmd_show_hide_bar (GtkAction *action, gpointer user_data)
 	if (priv->mode != EOM_WINDOW_MODE_NORMAL &&
             priv->mode != EOM_WINDOW_MODE_FULLSCREEN) return;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	visible = gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action));
+	action_name = gtk_action_get_name (action);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
-	if (g_ascii_strcasecmp (gtk_action_get_name (action), "ViewToolbar") == 0) {
+	if (g_ascii_strcasecmp (action_name, "ViewToolbar") == 0) {
 		g_object_set (G_OBJECT (priv->toolbar), "visible", visible, NULL);
 
 		if (priv->mode == EOM_WINDOW_MODE_NORMAL)
 			g_settings_set_boolean (priv->ui_settings, EOM_CONF_UI_TOOLBAR, visible);
 
-	} else if (g_ascii_strcasecmp (gtk_action_get_name (action), "ViewStatusbar") == 0) {
+	} else if (g_ascii_strcasecmp (action_name, "ViewStatusbar") == 0) {
 		g_object_set (G_OBJECT (priv->statusbar), "visible", visible, NULL);
 
 		if (priv->mode == EOM_WINDOW_MODE_NORMAL)
 			g_settings_set_boolean (priv->ui_settings, EOM_CONF_UI_STATUSBAR, visible);
 
-	} else if (g_ascii_strcasecmp (gtk_action_get_name (action), "ViewImageCollection") == 0) {
+	} else if (g_ascii_strcasecmp (action_name, "ViewImageCollection") == 0) {
 		if (visible) {
 			/* Make sure the focus widget is realized to
 			 * avoid warnings on keypress events */
@@ -2660,7 +2712,7 @@ eom_window_cmd_show_hide_bar (GtkAction *action, gpointer user_data)
 		}
 		g_settings_set_boolean (priv->ui_settings, EOM_CONF_UI_IMAGE_COLLECTION, visible);
 
-	} else if (g_ascii_strcasecmp (gtk_action_get_name (action), "ViewSidebar") == 0) {
+	} else if (g_ascii_strcasecmp (action_name, "ViewSidebar") == 0) {
 		if (visible) {
 			gtk_widget_show (priv->sidebar);
 		} else {
@@ -2795,9 +2847,11 @@ eom_job_save_cb (EomJobSave *job, gpointer user_data)
 	window->priv->save_job = NULL;
 
 	update_status_bar (window);
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action_save = gtk_action_group_get_action (window->priv->actions_image,
 						   "ImageSave");
 	gtk_action_set_sensitive (action_save, FALSE);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 }
 
 static void
@@ -2833,9 +2887,11 @@ eom_job_copy_cb (EomJobCopy *job, gpointer user_data)
 
 	gtk_statusbar_pop (GTK_STATUSBAR (window->priv->statusbar),
 			   window->priv->copy_file_cid);
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (window->priv->actions_image,
 					      "ImageSetAsWallpaper");
 	gtk_action_set_sensitive (action, TRUE);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	window->priv->copy_job = NULL;
 
@@ -3064,6 +3120,7 @@ eom_window_get_properties_dialog (EomWindow *window)
 	if (priv->properties_dlg == NULL) {
 		GtkAction *next_image_action, *previous_image_action;
 
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 		next_image_action =
 			gtk_action_group_get_action (priv->actions_collection,
 						     "GoNext");
@@ -3071,6 +3128,7 @@ eom_window_get_properties_dialog (EomWindow *window)
 		previous_image_action =
 			gtk_action_group_get_action (priv->actions_collection,
 						     "GoPrevious");
+		G_GNUC_END_IGNORE_DEPRECATIONS;
 		priv->properties_dlg =
 			eom_properties_dialog_new (GTK_WINDOW (window),
 						   EOM_THUMB_VIEW (priv->thumbview),
@@ -3177,9 +3235,11 @@ eom_window_cmd_wallpaper (GtkAction *action, gpointer user_data)
 		GList *files = NULL;
 		GtkAction *action;
 
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 		action = gtk_action_group_get_action (window->priv->actions_image,
 						      "ImageSetAsWallpaper");
 		gtk_action_set_sensitive (action, FALSE);
+		G_GNUC_END_IGNORE_DEPRECATIONS;
 
 		priv->copy_file_cid = gtk_statusbar_get_context_id (GTK_STATUSBAR (priv->statusbar),
 								    "copy_file_cid");
@@ -3413,6 +3473,7 @@ eom_window_cmd_move_to_trash (GtkAction *action, gpointer user_data)
 	int n_images;
 	gboolean success;
 	gboolean can_trash;
+	const gchar *action_name;
 
 	g_return_if_fail (EOM_IS_WINDOW (user_data));
 
@@ -3434,7 +3495,11 @@ eom_window_cmd_move_to_trash (GtkAction *action, gpointer user_data)
 
 	can_trash = eom_window_all_images_trasheable (images);
 
-	if (g_ascii_strcasecmp (gtk_action_get_name (action), "Delete") == 0 ||
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
+	action_name = gtk_action_get_name (action);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
+
+	if (g_ascii_strcasecmp (action_name, "Delete") == 0 ||
 	    can_trash == FALSE) {
 		response = show_move_to_trash_confirm_dialog (window, images, can_trash);
 
@@ -3513,7 +3578,9 @@ eom_window_cmd_fullscreen (GtkAction *action, gpointer user_data)
 
 	window = EOM_WINDOW (user_data);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	fullscreen = gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action));
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	if (fullscreen) {
 		eom_window_run_fullscreen (window, FALSE);
@@ -3534,7 +3601,9 @@ eom_window_cmd_slideshow (GtkAction *action, gpointer user_data)
 
 	window = EOM_WINDOW (user_data);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	slideshow = gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action));
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	if (slideshow) {
 		eom_window_run_fullscreen (window, TRUE);
@@ -3862,7 +3931,9 @@ menu_item_select_cb (GtkMenuItem *proxy, EomWindow *window)
 	GtkAction *action;
 	char *message;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_activatable_get_related_action (GTK_ACTIVATABLE (proxy));
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	g_return_if_fail (action != NULL);
 
@@ -3918,6 +3989,7 @@ set_action_properties (GtkActionGroup *window_group,
 {
         GtkAction *action;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
         action = gtk_action_group_get_action (collection_group, "GoPrevious");
         g_object_set (action, "short_label", _("Previous"), NULL);
         g_object_set (action, "is-important", TRUE, NULL);
@@ -3952,6 +4024,7 @@ set_action_properties (GtkActionGroup *window_group,
 
         action = gtk_action_group_get_action (image_group, "EditMoveToTrash");
         g_object_set (action, "short_label", C_("action (to trash)", "Trash"), NULL);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 }
 
 static gint
@@ -4004,6 +4077,7 @@ eom_window_update_recent_files_menu (EomWindow *window)
 	if (priv->recent_menu_id != 0)
 		gtk_ui_manager_remove_ui (priv->ui_mgr, priv->recent_menu_id);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	actions = gtk_action_group_list_actions (priv->actions_recent);
 
 	for (li = actions; li != NULL; li = li->next) {
@@ -4014,6 +4088,7 @@ eom_window_update_recent_files_menu (EomWindow *window)
 		gtk_action_group_remove_action (priv->actions_recent,
 						GTK_ACTION (li->data));
 	}
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	g_list_free (actions);
 
@@ -4055,8 +4130,10 @@ eom_window_update_recent_files_menu (EomWindow *window)
 		if (tip == NULL)
 			tip = g_uri_unescape_string (gtk_recent_info_get_uri (info), NULL);
 
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 		action = gtk_action_new (action_name, label, tip, NULL);
 		gtk_action_set_always_show_image (action, TRUE);
+		G_GNUC_END_IGNORE_DEPRECATIONS;
 
 		g_object_set_data_full (G_OBJECT (action), "gtk-recent-info",
 					gtk_recent_info_ref (info),
@@ -4068,7 +4145,9 @@ eom_window_update_recent_files_menu (EomWindow *window)
 				  G_CALLBACK (eom_window_open_recent_cb),
 				  window);
 
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 		gtk_action_group_add_action (priv->actions_recent, action);
+		G_GNUC_END_IGNORE_DEPRECATIONS;
 
 		g_object_unref (action);
 
@@ -4146,6 +4225,7 @@ eom_window_sidebar_visibility_changed (GtkWidget *widget, EomWindow *window)
 	GtkAction *action;
 	gboolean visible;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	visible = gtk_widget_get_visible (window->priv->sidebar);
 
 	action = gtk_action_group_get_action (window->priv->actions_window,
@@ -4153,6 +4233,7 @@ eom_window_sidebar_visibility_changed (GtkWidget *widget, EomWindow *window)
 
 	if (gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action)) != visible)
 		gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action), visible);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	/* Focus the image */
 	if (!visible && window->priv->image != NULL)
@@ -4168,12 +4249,14 @@ eom_window_sidebar_page_added (EomSidebar  *sidebar,
 		GtkAction *action;
 		gboolean show;
 
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 		action = gtk_action_group_get_action (window->priv->actions_window,
 						      "ViewSidebar");
 
 		gtk_action_set_sensitive (action, TRUE);
 
 		show = gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action));
+		G_GNUC_END_IGNORE_DEPRECATIONS;
 
 		if (show)
 			gtk_widget_show (GTK_WIDGET (sidebar));
@@ -4189,10 +4272,12 @@ eom_window_sidebar_page_removed (EomSidebar  *sidebar,
 
 		gtk_widget_hide (GTK_WIDGET (sidebar));
 
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 		action = gtk_action_group_get_action (window->priv->actions_window,
 						      "ViewSidebar");
 
 		gtk_action_set_sensitive (action, FALSE);
+		G_GNUC_END_IGNORE_DEPRECATIONS;
 	}
 }
 
@@ -4298,6 +4383,7 @@ eom_window_add_open_editor_action (EomWindow *window)
 
 	tooltip = g_strdup_printf (_("Edit the current image using %s"),
 	                           g_app_info_get_name (app_info));
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_new ("OpenEditor", _("Edit Image"), tooltip, NULL);
 	gtk_action_set_gicon (action, g_app_info_get_icon (app_info));
 	gtk_action_set_is_important (action, TRUE);
@@ -4306,6 +4392,7 @@ eom_window_add_open_editor_action (EomWindow *window)
 	                  G_CALLBACK (eom_window_open_editor), window);
 
 	gtk_action_group_add_action (window->priv->actions_image, action);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	g_object_unref (action);
 	g_free (tooltip);
@@ -4334,6 +4421,7 @@ eom_window_construct_ui (EomWindow *window)
 
 	priv->ui_mgr = gtk_ui_manager_new ();
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	priv->actions_window = gtk_action_group_new ("MenuActionsWindow");
 
 	gtk_action_group_set_translation_domain (priv->actions_window,
@@ -4348,9 +4436,11 @@ eom_window_construct_ui (EomWindow *window)
 					     toggle_entries_window,
 					     G_N_ELEMENTS (toggle_entries_window),
 					     window);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	gtk_ui_manager_insert_action_group (priv->ui_mgr, priv->actions_window, 0);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	priv->actions_image = gtk_action_group_new ("MenuActionsImage");
 	gtk_action_group_set_translation_domain (priv->actions_image,
 						 GETTEXT_PACKAGE);
@@ -4366,9 +4456,11 @@ eom_window_construct_ui (EomWindow *window)
 					     toggle_entries_image,
 					     G_N_ELEMENTS (toggle_entries_image),
 					     window);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	gtk_ui_manager_insert_action_group (priv->ui_mgr, priv->actions_image, 0);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	priv->actions_collection = gtk_action_group_new ("MenuActionsCollection");
 	gtk_action_group_set_translation_domain (priv->actions_collection,
 						 GETTEXT_PACKAGE);
@@ -4382,6 +4474,7 @@ eom_window_construct_ui (EomWindow *window)
 					     toggle_entries_collection,
 					     G_N_ELEMENTS (toggle_entries_collection),
 					     window);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	set_action_properties (priv->actions_window,
 			       priv->actions_image,
@@ -4450,9 +4543,11 @@ eom_window_construct_ui (EomWindow *window)
 	gtk_window_add_accel_group (GTK_WINDOW (window),
 				    gtk_ui_manager_get_accel_group (priv->ui_mgr));
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	priv->actions_recent = gtk_action_group_new ("RecentFilesActions");
 	gtk_action_group_set_translation_domain (priv->actions_recent,
 						 GETTEXT_PACKAGE);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	g_signal_connect (gtk_recent_manager_get_default (), "changed",
 			  G_CALLBACK (eom_window_recent_manager_changed_cb),


### PR DESCRIPTION
Suppress GtkAction warnings which can't be fixed without removing icons from menus.
So, no need to let them spam our build logs, in result you overlook really important warnings.
Show those warnings in debian build only, to make one team member happy.