### PR TITLE
remove warnings: redundant redeclaration [-Wredundant-decls]

### DIFF
--- a/cut-n-paste/toolbar-editor/egg-toolbars-model.h
+++ b/cut-n-paste/toolbar-editor/egg-toolbars-model.h
@@ -110,7 +110,6 @@ struct EggToolbarsItemType
                          const char          *data);
 };
 
-GType		  egg_tb_model_flags_get_type       (void);
 GType		  egg_toolbars_model_get_type       (void);
 EggToolbarsModel *egg_toolbars_model_new	    (void);
 gboolean          egg_toolbars_model_load_names     (EggToolbarsModel *model,

--- a/src/eom-thumb-view.c
+++ b/src/eom-thumb-view.c
@@ -45,8 +45,6 @@ enum {
 
 #define EOM_THUMB_VIEW_SPACING 0
 
-static void eom_thumb_view_init (EomThumbView *thumbview);
-
 static EomImage* eom_thumb_view_get_image_from_path (EomThumbView      *thumbview,
 						     GtkTreePath       *path);
 


### PR DESCRIPTION
```
egg-toolbars-model.h:113:10: warning: redundant redeclaration of ‘egg_tb_model_flags_get_type’ [-Wredundant-decls]
eggtypebuiltins.h:13:23: warning: redundant redeclaration of ‘egg_tb_model_flags_get_type’ [-Wredundant-decls]
eom-thumb-view.c:91:40: warning: redundant redeclaration of ‘eom_thumb_view_init’ [-Wredundant-decls]
```