### PR TITLE
remove warnings: incorrect usage of abs() [-Wabsolute-value]

### DIFF
--- a/src/eom-transform.c
+++ b/src/eom-transform.c
@@ -132,8 +132,8 @@ eom_transform_apply (EomTransform *trans, GdkPixbuf *pixbuf, EomJob *job)
 	}
 
 	/* create the resulting pixbuf */
-	dest_width = abs (dest_bottom_right.x - dest_top_left.x + 1);
-	dest_height = abs (dest_bottom_right.y - dest_top_left.y + 1);
+	dest_width = abs ((int) (dest_bottom_right.x - dest_top_left.x + 1));
+	dest_height = abs ((int) (dest_bottom_right.y - dest_top_left.y + 1));
 
 	dest_pixbuf = gdk_pixbuf_new (GDK_COLORSPACE_RGB,
 			       gdk_pixbuf_get_has_alpha (pixbuf),


### PR DESCRIPTION
```
eom-transform.c:135:15: warning: using integer absolute value function ‘abs’ when argument is of floating point type ‘gdouble’ {aka ‘double’} [-Wabsolute-value]
eom-transform.c:136:16: warning: using integer absolute value function ‘abs’ when argument is of floating point type ‘gdouble’ {aka ‘double’} [-Wabsolute-value]
```