### PR TITLE
add missing format specifier for ngettext

### DIFF
--- a/eom.pot
+++ b/eom.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-07-02 11:34+0200\n"
+"POT-Creation-Date: 2019-11-12 16:19+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,40 +25,40 @@ msgstr ""
 #. * produce duplicates, but don't worry about it. If your language
 #. * normally has a mnemonic at the start, please use the _. If not,
 #. * please remove.
-#: ../cut-n-paste/toolbar-editor/egg-editable-toolbar.c:930
+#: ../cut-n-paste/toolbar-editor/egg-editable-toolbar.c:946
 #, c-format
 msgid "Show “_%s”"
 msgstr ""
 
-#: ../cut-n-paste/toolbar-editor/egg-editable-toolbar.c:1396
+#: ../cut-n-paste/toolbar-editor/egg-editable-toolbar.c:1420
 msgid "_Move on Toolbar"
 msgstr ""
 
-#: ../cut-n-paste/toolbar-editor/egg-editable-toolbar.c:1397
+#: ../cut-n-paste/toolbar-editor/egg-editable-toolbar.c:1421
 msgid "Move the selected item on the toolbar"
 msgstr ""
 
-#: ../cut-n-paste/toolbar-editor/egg-editable-toolbar.c:1398
+#: ../cut-n-paste/toolbar-editor/egg-editable-toolbar.c:1422
 msgid "_Remove from Toolbar"
 msgstr ""
 
-#: ../cut-n-paste/toolbar-editor/egg-editable-toolbar.c:1399
+#: ../cut-n-paste/toolbar-editor/egg-editable-toolbar.c:1423
 msgid "Remove the selected item from the toolbar"
 msgstr ""
 
-#: ../cut-n-paste/toolbar-editor/egg-editable-toolbar.c:1400
+#: ../cut-n-paste/toolbar-editor/egg-editable-toolbar.c:1424
 msgid "_Delete Toolbar"
 msgstr ""
 
-#: ../cut-n-paste/toolbar-editor/egg-editable-toolbar.c:1401
+#: ../cut-n-paste/toolbar-editor/egg-editable-toolbar.c:1425
 msgid "Remove the selected toolbar"
 msgstr ""
 
-#: ../cut-n-paste/toolbar-editor/egg-toolbar-editor.c:485
+#: ../cut-n-paste/toolbar-editor/egg-toolbar-editor.c:483
 msgid "Separator"
 msgstr ""
 
-#: ../data/eom.appdata.xml.in.h:1 ../src/eom-window.c:2585
+#: ../data/eom.appdata.xml.in.h:1 ../src/eom-window.c:2636
 msgid "Eye of MATE"
 msgstr ""
 
@@ -680,7 +680,7 @@ msgstr ""
 
 #. Pixel size of image: width x height in pixel
 #: ../src/eom-file-chooser.c:281 ../src/eom-properties-dialog.c:163
-#: ../src/eom-properties-dialog.c:165 ../src/eom-thumb-view.c:518
+#: ../src/eom-properties-dialog.c:165 ../src/eom-thumb-view.c:516
 msgid "pixel"
 msgid_plural "pixels"
 msgstr[0] ""
@@ -694,7 +694,7 @@ msgstr ""
 msgid "Save Image"
 msgstr ""
 
-#: ../src/eom-file-chooser.c:467 ../src/eom-window.c:3933
+#: ../src/eom-file-chooser.c:467 ../src/eom-window.c:4005
 msgid "Open Folder"
 msgstr ""
 
@@ -708,22 +708,22 @@ msgstr ""
 msgid "Transformation failed."
 msgstr ""
 
-#: ../src/eom-image.c:1020
+#: ../src/eom-image.c:1048
 #, c-format
 msgid "EXIF not supported for this file format."
 msgstr ""
 
-#: ../src/eom-image.c:1169
+#: ../src/eom-image.c:1197
 #, c-format
 msgid "Image loading failed."
 msgstr ""
 
-#: ../src/eom-image.c:1698 ../src/eom-image.c:1800
+#: ../src/eom-image.c:1726 ../src/eom-image.c:1828
 #, c-format
 msgid "No image loaded."
 msgstr ""
 
-#: ../src/eom-image.c:1708 ../src/eom-image.c:1812
+#: ../src/eom-image.c:1736 ../src/eom-image.c:1840
 #, c-format
 msgid "Temporary file creation failed."
 msgstr ""
@@ -963,7 +963,7 @@ msgstr ""
 msgid "%d / %d"
 msgstr ""
 
-#: ../src/eom-thumb-view.c:546
+#: ../src/eom-thumb-view.c:544
 msgid "Taken on"
 msgstr ""
 
@@ -986,32 +986,32 @@ msgstr ""
 #. * - image height
 #. * - image size in bytes
 #. * - zoom in percent
-#: ../src/eom-window.c:512
+#: ../src/eom-window.c:517
 #, c-format
 msgid "%i × %i pixel  %s    %i%%"
 msgid_plural "%i × %i pixels  %s    %i%%"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/eom-window.c:813
+#: ../src/eom-window.c:828
 msgid "_Reload"
 msgstr ""
 
-#: ../src/eom-window.c:815 ../src/eom-window.c:2735
+#: ../src/eom-window.c:830 ../src/eom-window.c:2790
 msgctxt "MessageArea"
 msgid "Hi_de"
 msgstr ""
 
 #. The newline character is currently necessary due to a problem
 #. * with the automatic line break.
-#: ../src/eom-window.c:825
+#: ../src/eom-window.c:840
 #, c-format
 msgid ""
 "The image \"%s\" has been modified by an external application.\n"
 "Would you like to reload it?"
 msgstr ""
 
-#: ../src/eom-window.c:991
+#: ../src/eom-window.c:1008
 #, c-format
 msgid "Use \"%s\" to open the selected image"
 msgstr ""
@@ -1021,40 +1021,40 @@ msgstr ""
 #. * - the original filename
 #. * - the current image's position in the queue
 #. * - the total number of images queued for saving
-#: ../src/eom-window.c:1147
+#: ../src/eom-window.c:1172
 #, c-format
 msgid "Saving image \"%s\" (%u/%u)"
 msgstr ""
 
-#: ../src/eom-window.c:1506
+#: ../src/eom-window.c:1539
 #, c-format
 msgid "Opening image \"%s\""
 msgstr ""
 
-#: ../src/eom-window.c:1862
+#: ../src/eom-window.c:1905
 msgid "Leave Fullscreen"
 msgstr ""
 
-#: ../src/eom-window.c:1995
+#: ../src/eom-window.c:2046
 msgid "Viewing a slideshow"
 msgstr ""
 
-#: ../src/eom-window.c:2208
+#: ../src/eom-window.c:2259
 #, c-format
 msgid ""
 "Error printing file:\n"
 "%s"
 msgstr ""
 
-#: ../src/eom-window.c:2471
+#: ../src/eom-window.c:2522
 msgid "Toolbar Editor"
 msgstr ""
 
-#: ../src/eom-window.c:2474
+#: ../src/eom-window.c:2525
 msgid "_Reset to Default"
 msgstr ""
 
-#: ../src/eom-window.c:2539
+#: ../src/eom-window.c:2590
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
 "under the terms of the GNU General Public License as published by the Free "
@@ -1062,7 +1062,7 @@ msgid ""
 "any later version.\n"
 msgstr ""
 
-#: ../src/eom-window.c:2543
+#: ../src/eom-window.c:2594
 msgid ""
 "This program is distributed in the hope that it will be useful, but WITHOUT "
 "ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or "
@@ -1070,469 +1070,469 @@ msgid ""
 "more details.\n"
 msgstr ""
 
-#: ../src/eom-window.c:2547
+#: ../src/eom-window.c:2598
 msgid ""
 "You should have received a copy of the GNU General Public License along with "
 "this program; if not, write to the Free Software Foundation, Inc., 51 "
 "Franklin St, Fifth Floor, Boston, MA 02110-1301, USA."
 msgstr ""
 
-#: ../src/eom-window.c:2586
+#: ../src/eom-window.c:2637
 msgid "About Eye of MATE"
 msgstr ""
 
-#: ../src/eom-window.c:2588
+#: ../src/eom-window.c:2639
 msgid ""
 "Copyright © 2000-2010 Free Software Foundation, Inc.\n"
 "Copyright © 2011 Perberos\n"
 "Copyright © 2012-2019 MATE developers"
 msgstr ""
 
-#: ../src/eom-window.c:2591
+#: ../src/eom-window.c:2642
 msgid "The MATE image viewer."
 msgstr ""
 
-#: ../src/eom-window.c:2594
+#: ../src/eom-window.c:2645
 msgid "translator-credits"
 msgstr ""
 
-#: ../src/eom-window.c:2683 ../src/eom-window.c:2698
+#: ../src/eom-window.c:2738 ../src/eom-window.c:2753
 msgid "Error launching appearance preferences dialog: "
 msgstr ""
 
 #. I18N: When setting mnemonics for these strings, watch out to not
 #. clash with mnemonics from eom's menubar
-#: ../src/eom-window.c:2733
+#: ../src/eom-window.c:2788
 msgid "_Open Background Preferences"
 msgstr ""
 
 #. The newline character is currently necessary due to a problem
 #. * with the automatic line break.
-#: ../src/eom-window.c:2749
+#: ../src/eom-window.c:2804
 #, c-format
 msgid ""
 "The image \"%s\" has been set as Desktop Background.\n"
 "Would you like to modify its appearance?"
 msgstr ""
 
-#: ../src/eom-window.c:3185
+#: ../src/eom-window.c:3245
 msgid "Saving image locally…"
 msgstr ""
 
-#: ../src/eom-window.c:3265
+#: ../src/eom-window.c:3325
 #, c-format
 msgid ""
 "Are you sure you want to move\n"
 "\"%s\" to the trash?"
 msgstr ""
 
-#: ../src/eom-window.c:3268
+#: ../src/eom-window.c:3328
 #, c-format
 msgid ""
 "A trash for \"%s\" couldn't be found. Do you want to remove this image "
 "permanently?"
 msgstr ""
 
-#: ../src/eom-window.c:3273
+#: ../src/eom-window.c:3333
 #, c-format
 msgid ""
 "Are you sure you want to move\n"
-"the selected image to the trash?"
+"the %d selected image to the trash?"
 msgid_plural ""
 "Are you sure you want to move\n"
 "the %d selected images to the trash?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/eom-window.c:3278
+#: ../src/eom-window.c:3338
 msgid ""
 "Some of the selected images can't be moved to the trash and will be removed "
 "permanently. Are you sure you want to proceed?"
 msgstr ""
 
-#: ../src/eom-window.c:3295 ../src/eom-window.c:3782 ../src/eom-window.c:3809
+#: ../src/eom-window.c:3355 ../src/eom-window.c:3851 ../src/eom-window.c:3878
 msgid "Move to _Trash"
 msgstr ""
 
-#: ../src/eom-window.c:3297
+#: ../src/eom-window.c:3357
 msgid "_Do not ask again during this session"
 msgstr ""
 
-#: ../src/eom-window.c:3342 ../src/eom-window.c:3356
+#: ../src/eom-window.c:3402 ../src/eom-window.c:3416
 #, c-format
 msgid "Couldn't access trash."
 msgstr ""
 
-#: ../src/eom-window.c:3364
+#: ../src/eom-window.c:3424
 #, c-format
 msgid "Couldn't delete file"
 msgstr ""
 
-#: ../src/eom-window.c:3461
+#: ../src/eom-window.c:3526
 #, c-format
 msgid "Error on deleting image %s"
 msgstr ""
 
-#: ../src/eom-window.c:3703
+#: ../src/eom-window.c:3772
 msgid "_Image"
 msgstr ""
 
-#: ../src/eom-window.c:3704
+#: ../src/eom-window.c:3773
 msgid "_Edit"
 msgstr ""
 
-#: ../src/eom-window.c:3705
+#: ../src/eom-window.c:3774
 msgid "_View"
 msgstr ""
 
-#: ../src/eom-window.c:3706
+#: ../src/eom-window.c:3775
 msgid "_Go"
 msgstr ""
 
-#: ../src/eom-window.c:3707
+#: ../src/eom-window.c:3776
 msgid "_Tools"
 msgstr ""
 
-#: ../src/eom-window.c:3708
+#: ../src/eom-window.c:3777
 msgid "_Help"
 msgstr ""
 
-#: ../src/eom-window.c:3710
+#: ../src/eom-window.c:3779
 msgid "_Open…"
 msgstr ""
 
-#: ../src/eom-window.c:3711
+#: ../src/eom-window.c:3780
 msgid "Open a file"
 msgstr ""
 
-#: ../src/eom-window.c:3713
+#: ../src/eom-window.c:3782
 msgid "_Close"
 msgstr ""
 
-#: ../src/eom-window.c:3714
+#: ../src/eom-window.c:3783
 msgid "Close window"
 msgstr ""
 
-#: ../src/eom-window.c:3716
+#: ../src/eom-window.c:3785
 msgid "T_oolbar"
 msgstr ""
 
-#: ../src/eom-window.c:3717
+#: ../src/eom-window.c:3786
 msgid "Edit the application toolbar"
 msgstr ""
 
-#: ../src/eom-window.c:3719
+#: ../src/eom-window.c:3788
 msgid "Prefere_nces"
 msgstr ""
 
-#: ../src/eom-window.c:3720
+#: ../src/eom-window.c:3789
 msgid "Preferences for Eye of MATE"
 msgstr ""
 
-#: ../src/eom-window.c:3722
+#: ../src/eom-window.c:3791
 msgid "_Contents"
 msgstr ""
 
-#: ../src/eom-window.c:3723
+#: ../src/eom-window.c:3792
 msgid "Help on this application"
 msgstr ""
 
-#: ../src/eom-window.c:3725
+#: ../src/eom-window.c:3794
 msgid "_About"
 msgstr ""
 
-#: ../src/eom-window.c:3726
+#: ../src/eom-window.c:3795
 msgid "About this application"
 msgstr ""
 
-#: ../src/eom-window.c:3731
+#: ../src/eom-window.c:3800
 msgid "_Toolbar"
 msgstr ""
 
-#: ../src/eom-window.c:3732
+#: ../src/eom-window.c:3801
 msgid "Changes the visibility of the toolbar in the current window"
 msgstr ""
 
-#: ../src/eom-window.c:3734
+#: ../src/eom-window.c:3803
 msgid "_Statusbar"
 msgstr ""
 
-#: ../src/eom-window.c:3735
+#: ../src/eom-window.c:3804
 msgid "Changes the visibility of the statusbar in the current window"
 msgstr ""
 
-#: ../src/eom-window.c:3737
+#: ../src/eom-window.c:3806
 msgid "_Image Collection"
 msgstr ""
 
-#: ../src/eom-window.c:3738
+#: ../src/eom-window.c:3807
 msgid ""
 "Changes the visibility of the image collection pane in the current window"
 msgstr ""
 
-#: ../src/eom-window.c:3740
+#: ../src/eom-window.c:3809
 msgid "Side _Pane"
 msgstr ""
 
-#: ../src/eom-window.c:3741
+#: ../src/eom-window.c:3810
 msgid "Changes the visibility of the side pane in the current window"
 msgstr ""
 
-#: ../src/eom-window.c:3746
+#: ../src/eom-window.c:3815
 msgid "_Save"
 msgstr ""
 
-#: ../src/eom-window.c:3747
+#: ../src/eom-window.c:3816
 msgid "Save changes in currently selected images"
 msgstr ""
 
-#: ../src/eom-window.c:3749
+#: ../src/eom-window.c:3818
 msgid "Open _with"
 msgstr ""
 
-#: ../src/eom-window.c:3750
+#: ../src/eom-window.c:3819
 msgid "Open the selected image with a different application"
 msgstr ""
 
-#: ../src/eom-window.c:3752
+#: ../src/eom-window.c:3821
 msgid "Save _As…"
 msgstr ""
 
-#: ../src/eom-window.c:3753
+#: ../src/eom-window.c:3822
 msgid "Save the selected images with a different name"
 msgstr ""
 
-#: ../src/eom-window.c:3755
+#: ../src/eom-window.c:3824
 msgid "Open Containing _Folder"
 msgstr ""
 
-#: ../src/eom-window.c:3756
+#: ../src/eom-window.c:3825
 msgid "Show the folder which contains this file in the file manager"
 msgstr ""
 
-#: ../src/eom-window.c:3758
+#: ../src/eom-window.c:3827
 msgid "_Print…"
 msgstr ""
 
-#: ../src/eom-window.c:3759
+#: ../src/eom-window.c:3828
 msgid "Print the selected image"
 msgstr ""
 
-#: ../src/eom-window.c:3761
+#: ../src/eom-window.c:3830
 msgid "Prope_rties"
 msgstr ""
 
-#: ../src/eom-window.c:3762
+#: ../src/eom-window.c:3831
 msgid "Show the properties and metadata of the selected image"
 msgstr ""
 
-#: ../src/eom-window.c:3764
+#: ../src/eom-window.c:3833
 msgid "_Undo"
 msgstr ""
 
-#: ../src/eom-window.c:3765
+#: ../src/eom-window.c:3834
 msgid "Undo the last change in the image"
 msgstr ""
 
-#: ../src/eom-window.c:3767
+#: ../src/eom-window.c:3836
 msgid "Flip _Horizontal"
 msgstr ""
 
-#: ../src/eom-window.c:3768
+#: ../src/eom-window.c:3837
 msgid "Mirror the image horizontally"
 msgstr ""
 
-#: ../src/eom-window.c:3770
+#: ../src/eom-window.c:3839
 msgid "Flip _Vertical"
 msgstr ""
 
-#: ../src/eom-window.c:3771
+#: ../src/eom-window.c:3840
 msgid "Mirror the image vertically"
 msgstr ""
 
-#: ../src/eom-window.c:3773
+#: ../src/eom-window.c:3842
 msgid "_Rotate Clockwise"
 msgstr ""
 
-#: ../src/eom-window.c:3774
+#: ../src/eom-window.c:3843
 msgid "Rotate the image 90 degrees to the right"
 msgstr ""
 
-#: ../src/eom-window.c:3776
+#: ../src/eom-window.c:3845
 msgid "Rotate Counterc_lockwise"
 msgstr ""
 
-#: ../src/eom-window.c:3777
+#: ../src/eom-window.c:3846
 msgid "Rotate the image 90 degrees to the left"
 msgstr ""
 
-#: ../src/eom-window.c:3779
+#: ../src/eom-window.c:3848
 msgid "Set as _Desktop Background"
 msgstr ""
 
-#: ../src/eom-window.c:3780
+#: ../src/eom-window.c:3849
 msgid "Set the selected image as the desktop background"
 msgstr ""
 
-#: ../src/eom-window.c:3783
+#: ../src/eom-window.c:3852
 msgid "Move the selected image to the trash folder"
 msgstr ""
 
-#: ../src/eom-window.c:3785
+#: ../src/eom-window.c:3854
 msgid "_Copy"
 msgstr ""
 
-#: ../src/eom-window.c:3786
+#: ../src/eom-window.c:3855
 msgid "Copy the selected image to the clipboard"
 msgstr ""
 
-#: ../src/eom-window.c:3788 ../src/eom-window.c:3800 ../src/eom-window.c:3803
+#: ../src/eom-window.c:3857 ../src/eom-window.c:3869 ../src/eom-window.c:3872
 msgid "_Zoom In"
 msgstr ""
 
-#: ../src/eom-window.c:3789 ../src/eom-window.c:3801
+#: ../src/eom-window.c:3858 ../src/eom-window.c:3870
 msgid "Enlarge the image"
 msgstr ""
 
-#: ../src/eom-window.c:3791 ../src/eom-window.c:3806
+#: ../src/eom-window.c:3860 ../src/eom-window.c:3875
 msgid "Zoom _Out"
 msgstr ""
 
-#: ../src/eom-window.c:3792 ../src/eom-window.c:3804 ../src/eom-window.c:3807
+#: ../src/eom-window.c:3861 ../src/eom-window.c:3873 ../src/eom-window.c:3876
 msgid "Shrink the image"
 msgstr ""
 
-#: ../src/eom-window.c:3794
+#: ../src/eom-window.c:3863
 msgid "_Normal Size"
 msgstr ""
 
-#: ../src/eom-window.c:3795
+#: ../src/eom-window.c:3864
 msgid "Show the image at its normal size"
 msgstr ""
 
-#: ../src/eom-window.c:3797
+#: ../src/eom-window.c:3866
 msgid "_Best Fit"
 msgstr ""
 
-#: ../src/eom-window.c:3798
+#: ../src/eom-window.c:3867
 msgid "Fit the image to the window"
 msgstr ""
 
-#: ../src/eom-window.c:3815
+#: ../src/eom-window.c:3884
 msgid "_Fullscreen"
 msgstr ""
 
-#: ../src/eom-window.c:3816
+#: ../src/eom-window.c:3885
 msgid "Show the current image in fullscreen mode"
 msgstr ""
 
-#: ../src/eom-window.c:3818
+#: ../src/eom-window.c:3887
 msgid "Pause Slideshow"
 msgstr ""
 
-#: ../src/eom-window.c:3819
+#: ../src/eom-window.c:3888
 msgid "Pause or resume the slideshow"
 msgstr ""
 
-#: ../src/eom-window.c:3824 ../src/eom-window.c:3839
+#: ../src/eom-window.c:3893 ../src/eom-window.c:3908
 msgid "_Previous Image"
 msgstr ""
 
-#: ../src/eom-window.c:3825
+#: ../src/eom-window.c:3894
 msgid "Go to the previous image of the collection"
 msgstr ""
 
-#: ../src/eom-window.c:3827
+#: ../src/eom-window.c:3896
 msgid "_Next Image"
 msgstr ""
 
-#: ../src/eom-window.c:3828
+#: ../src/eom-window.c:3897
 msgid "Go to the next image of the collection"
 msgstr ""
 
-#: ../src/eom-window.c:3830 ../src/eom-window.c:3842
+#: ../src/eom-window.c:3899 ../src/eom-window.c:3911
 msgid "_First Image"
 msgstr ""
 
-#: ../src/eom-window.c:3831
+#: ../src/eom-window.c:3900
 msgid "Go to the first image of the collection"
 msgstr ""
 
-#: ../src/eom-window.c:3833 ../src/eom-window.c:3845
+#: ../src/eom-window.c:3902 ../src/eom-window.c:3914
 msgid "_Last Image"
 msgstr ""
 
-#: ../src/eom-window.c:3834
+#: ../src/eom-window.c:3903
 msgid "Go to the last image of the collection"
 msgstr ""
 
-#: ../src/eom-window.c:3836
+#: ../src/eom-window.c:3905
 msgid "_Random Image"
 msgstr ""
 
-#: ../src/eom-window.c:3837
+#: ../src/eom-window.c:3906
 msgid "Go to a random image of the collection"
 msgstr ""
 
-#: ../src/eom-window.c:3851
+#: ../src/eom-window.c:3920
 msgid "S_lideshow"
 msgstr ""
 
-#: ../src/eom-window.c:3852
+#: ../src/eom-window.c:3921
 msgid "Start a slideshow view of the images"
 msgstr ""
 
-#: ../src/eom-window.c:3919
+#: ../src/eom-window.c:3991
 msgid "Previous"
 msgstr ""
 
-#: ../src/eom-window.c:3923
+#: ../src/eom-window.c:3995
 msgid "Next"
 msgstr ""
 
-#: ../src/eom-window.c:3927
+#: ../src/eom-window.c:3999
 msgid "Right"
 msgstr ""
 
-#: ../src/eom-window.c:3930
+#: ../src/eom-window.c:4002
 msgid "Left"
 msgstr ""
 
-#: ../src/eom-window.c:3936
+#: ../src/eom-window.c:4008
 msgid "In"
 msgstr ""
 
-#: ../src/eom-window.c:3939
+#: ../src/eom-window.c:4011
 msgid "Out"
 msgstr ""
 
-#: ../src/eom-window.c:3942
+#: ../src/eom-window.c:4014
 msgid "Normal"
 msgstr ""
 
-#: ../src/eom-window.c:3945
+#: ../src/eom-window.c:4017
 msgid "Fit"
 msgstr ""
 
-#: ../src/eom-window.c:3948
+#: ../src/eom-window.c:4020
 msgid "Collection"
 msgstr ""
 
-#: ../src/eom-window.c:3951
+#: ../src/eom-window.c:4023
 msgctxt "action (to trash)"
 msgid "Trash"
 msgstr ""
 
-#: ../src/eom-window.c:4296
+#: ../src/eom-window.c:4381
 #, c-format
 msgid "Edit the current image using %s"
 msgstr ""
 
-#: ../src/eom-window.c:4298
+#: ../src/eom-window.c:4384
 msgid "Edit Image"
 msgstr ""
 
-#: ../src/eom-window.c:4513
+#: ../src/eom-window.c:4608
 msgid "Properties"
 msgstr ""
 

--- a/src/eom-window.c
+++ b/src/eom-window.c
@@ -3331,7 +3331,7 @@ show_move_to_trash_confirm_dialog (EomWindow *window, GList *images, gboolean ca
 	} else {
 		if (can_trash) {
 			prompt = g_strdup_printf (ngettext("Are you sure you want to move\n"
-							   "the selected image to the trash?",
+							   "the %d selected image to the trash?",
 							   "Are you sure you want to move\n"
 							   "the %d selected images to the trash?", n_images), n_images);
 		} else {


### PR DESCRIPTION
This should fix problems with `msgstr[0]` mentioned at https://github.com/mate-desktop/eom/pull/245.

Note that our other projects have similar code, e.g. in right-click menu in Caja:

```C
if (selection_count == 0 || selection_count == 1) {
    label_with_underscore = g_strdup (_("Open in New _Window"));
} else {
    label_with_underscore = g_strdup_printf (ngettext("Open in %'d New _Window",
                                                      "Open in %'d New _Windows",
                                                      selection_count),
                                             selection_count);
}
```

Translation for one window:
```po
#. add the "open in new window" menu item
#: ../src/file-manager/fm-directory-view.c:8579
#: ../src/file-manager/fm-directory-view.c:8896
#: ../src/file-manager/fm-tree-view.c:1284 ../src/caja-places-sidebar.c:2692
msgid "Open in New _Window"
msgstr "Открыть в _новом окне"
```
Translation for multiple windows:
```po
#: ../src/file-manager/fm-directory-view.c:8898
#, c-format
msgid "Open in %'d New _Window"
msgid_plural "Open in %'d New _Windows"
msgstr[0] "Открыть в %'d _новом окне"
msgstr[1] "Открыть в %'d _новых окнах"
msgstr[2] "Открыть в %'d _новых окнах"
msgstr[3] "Открыть в %'d _новых окнах"
```