### PR TITLE
Remove preprocessing warnings

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -132,6 +132,7 @@ libeom_la_SOURCES +=			\
 endif HAVE_EXEMPI
 
 libeom_la_CPPFLAGS =						\
+	-I$(srcdir)						\
 	-I$(top_srcdir)						\
 	-I$(top_srcdir)/jpegutils				\
 	-I$(top_srcdir)/cut-n-paste/toolbar-editor		\

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -132,6 +132,7 @@ libeom_la_SOURCES +=			\
 endif HAVE_EXEMPI
 
 libeom_la_CPPFLAGS =						\
+	-I$(top_srcdir)						\
 	-I$(top_srcdir)/jpegutils				\
 	-I$(top_srcdir)/cut-n-paste/toolbar-editor		\
 	-DG_LOG_DOMAIN=\"EOM\"					\


### PR DESCRIPTION
Preprocessing warning for file: src/eom-print.c
```
eom-print.c:22:20: Cannot find include file config.h on search path:
    /home/robert/eom/src;.;../jpegutils;../cut-n-paste/toolbar-editor;/usr/inclu
    de/gtk-3.0;/usr/include/pango-1.0;/usr/include/glib-2.0;/usr/lib64/glib-2.0/
    include;/usr/include/harfbuzz;/usr/include/fribidi;/usr/include/freetype2;/u
    sr/include/libpng16;/usr/include/cairo;/usr/include/pixman-1;/usr/include/gd
    k-pixbuf-2.0;/usr/include/libmount;/usr/include/blkid;/usr/include/gio-unix-
    2.0;/usr/include/atk-1.0;/usr/include/at-spi2-atk/2.0;/usr/include/at-spi-2.
    0;/usr/include/dbus-1.0;/usr/lib64/dbus-1.0/include;/usr/include/mate-deskto
    p-2.0;/usr/include/startup-notification-1.0;/usr/include/dconf;/usr/include/
    gtk-3.0/unix-print;/usr/include/libpeas-1.0;/usr/include/gobject-introspecti
    on-1.0;/usr/include/exempi-2.0;/usr/include/librsvg-2.0;/usr/include;/usr/in
    clude
```
Preprocessing warning for file: src/eom-window.c
```
eom-close-confirmation-dialog.h:33:23:
    Cannot find include file eom-image.h on search path: ..;../jpegutils;../cut-
    n-paste/toolbar-editor;/usr/include/gtk-3.0;/usr/include/pango-1.0;/usr/incl
    ude/glib-2.0;/usr/lib64/glib-2.0/include;/usr/include/harfbuzz;/usr/include/
    fribidi;/usr/include/freetype2;/usr/include/libpng16;/usr/include/cairo;/usr
    /include/pixman-1;/usr/include/gdk-pixbuf-2.0;/usr/include/libmount;/usr/inc
    lude/blkid;/usr/include/gio-unix-2.0;/usr/include/atk-1.0;/usr/include/at-sp
    i2-atk/2.0;/usr/include/at-spi-2.0;/usr/include/dbus-1.0;/usr/lib64/dbus-1.0
    /include;/usr/include/mate-desktop-2.0;/usr/include/startup-notification-1.0
    ;/usr/include/dconf;/usr/include/gtk-3.0/unix-print;/usr/include/libpeas-1.0
    ;/usr/include/gobject-introspection-1.0;/usr/include/exempi-2.0;/usr/include
    /librsvg-2.0;/usr/include;/usr/include
   In file included from eom-window.c:54
```
