### PR TITLE
help: Fix Image Collection shortcut

### DIFF
--- a/help/C/index.docbook
+++ b/help/C/index.docbook
@@ -370,7 +370,7 @@
 	<varlistentry>
 	  <term>Image Collection</term>
 	  <listitem>
-	    <para>The image collection shows you all supported images in the current working directory. It shows up once an image has been loaded. To show or hide the collection, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Image Collection</guimenuitem></menuchoice> or press <keycap>F9</keycap>.</para>
+	    <para>The image collection shows you all supported images in the current working directory. It shows up once an image has been loaded. To show or hide the collection, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Image Collection</guimenuitem></menuchoice> or press <keycombo><keycap>Ctrl</keycap><keycap>F9</keycap></keycombo>.</para>
 	  </listitem>
 	</varlistentry>
 	<varlistentry>

--- a/help/C/index.docbook
+++ b/help/C/index.docbook
@@ -437,7 +437,7 @@
                   </listitem>
                   <listitem>
                     <para>
-                      Open the image collection by choosing <menuchoice><guimenu>View</guimenu><guimenuitem>Image Collection</guimenuitem></menuchoice> or pressing <keycap>F9</keycap>.
+                      Open the image collection by choosing <menuchoice><guimenu>View</guimenu><guimenuitem>Image Collection</guimenuitem></menuchoice> or pressing <keycombo><keycap>Ctrl</keycap><keycap>F9</keycap></keycombo>.
                     </para>
                   </listitem>
 		</orderedlist>


### PR DESCRIPTION
Reported by translators. It's Ctrl+ F9 and not F9.

Test:
```shell
$ yelp help:eom/eom-whenyoustart
```
![Screenshot at 2020-02-27 19-51-31](https://user-images.githubusercontent.com/10171411/75476790-81296c80-599b-11ea-9596-1a17fc5d3d35.png)

```
$ yelp help:eom/eom-open-folder
```
![Screenshot at 2020-02-28 11-59-40](https://user-images.githubusercontent.com/10171411/75543462-20914280-5a22-11ea-9d9b-14c2dbe24da2.png)

Closes #262