### PR TITLE
Remove warnings: cast between incompatible function types

### DIFF
--- a/cut-n-paste/toolbar-editor/egg-editable-toolbar.c
+++ b/cut-n-paste/toolbar-editor/egg-editable-toolbar.c
@@ -1312,8 +1312,7 @@ egg_editable_toolbar_deconstruct (EggEditableToolbar *toolbar)
     }
 
   children = gtk_container_get_children (GTK_CONTAINER (toolbar));
-  g_list_foreach (children, (GFunc) gtk_widget_destroy, NULL);
-  g_list_free (children);
+  g_list_free_full (children, (GDestroyNotify) gtk_widget_destroy);
 }
 
 void
@@ -1382,8 +1381,7 @@ egg_editable_toolbar_dispose (GObject *object)
   if (priv->visibility_paths)
     {
       children = priv->visibility_paths;
-      g_list_foreach (children, (GFunc) g_free, NULL);
-      g_list_free (children);
+      g_list_free_full (children, g_free);
       priv->visibility_paths = NULL;
     }
 

--- a/src/eom-image.c
+++ b/src/eom-image.c
@@ -199,8 +199,7 @@ eom_image_dispose (GObject *object)
 	}
 
 	if (priv->undo_stack) {
-		g_slist_foreach (priv->undo_stack, (GFunc) g_object_unref, NULL);
-		g_slist_free (priv->undo_stack);
+		g_slist_free_full (priv->undo_stack, g_object_unref);
 		priv->undo_stack = NULL;
 	}
 
@@ -1649,8 +1648,7 @@ eom_image_reset_modifications (EomImage *image)
 
 	priv = image->priv;
 
-	g_slist_foreach (priv->undo_stack, (GFunc) g_object_unref, NULL);
-	g_slist_free (priv->undo_stack);
+	g_slist_free_full (priv->undo_stack, g_object_unref);
 	priv->undo_stack = NULL;
 
 	if (priv->trans != NULL) {

--- a/src/eom-jobs.c
+++ b/src/eom-jobs.c
@@ -443,11 +443,8 @@ eom_job_model_run (EomJob *ejob)
 
 	eom_list_store_add_files (job->store, filtered_list);
 
-	g_list_foreach (filtered_list, (GFunc) g_object_unref, NULL);
-	g_list_free (filtered_list);
-
-	g_list_foreach (error_list, (GFunc) g_free, NULL);
-	g_list_free (error_list);
+	g_list_free_full (filtered_list, g_object_unref);
+	g_list_free_full (error_list, g_free);
 
 	ejob->finished = TRUE;
 }
@@ -466,8 +463,7 @@ eom_job_transform_dispose (GObject *object)
 		job->trans = NULL;
 	}
 
-	g_list_foreach (job->images, (GFunc) g_object_unref, NULL);
-	g_list_free (job->images);
+	g_list_free_full (job->images, g_object_unref);
 
 	(* G_OBJECT_CLASS (eom_job_transform_parent_class)->dispose) (object);
 }
@@ -566,8 +562,7 @@ eom_job_save_dispose (GObject *object)
 	job = EOM_JOB_SAVE (object);
 
 	if (job->images) {
-		g_list_foreach (job->images, (GFunc) g_object_unref, NULL);
-		g_list_free (job->images);
+		g_list_free_full (job->images, g_object_unref);
 		job->images = NULL;
 	}
 

--- a/src/eom-thumb-view.c
+++ b/src/eom-thumb-view.c
@@ -856,8 +856,7 @@ eom_thumb_view_get_first_selected_image (EomThumbView *thumbview)
 
 	image = eom_thumb_view_get_image_from_path (thumbview, path);
 
-	g_list_foreach (list, (GFunc) gtk_tree_path_free , NULL);
-	g_list_free (list);
+	g_list_free_full (list, (GDestroyNotify) gtk_tree_path_free);
 
 	return image;
 }
@@ -983,8 +982,7 @@ eom_thumb_view_select_single (EomThumbView *thumbview,
 	} else {
 		list = gtk_icon_view_get_selected_items (GTK_ICON_VIEW (thumbview));
 		path = gtk_tree_path_copy ((GtkTreePath *) list->data);
-		g_list_foreach (list, (GFunc) gtk_tree_path_free , NULL);
-		g_list_free (list);
+		g_list_free_full (list, (GDestroyNotify) gtk_tree_path_free);
 
 		gtk_icon_view_unselect_all (GTK_ICON_VIEW (thumbview));
 

--- a/src/eom-uri-converter.c
+++ b/src/eom-uri-converter.c
@@ -79,8 +79,7 @@ eom_uri_converter_dispose (GObject *object)
 	}
 
 	if (priv->token_list) {
-		g_list_foreach (priv->token_list, (GFunc) free_token, NULL);
-		g_list_free (priv->token_list);
+		g_list_free_full (priv->token_list, free_token);
 		priv->token_list = NULL;
 	}
 

--- a/src/eom-window.c
+++ b/src/eom-window.c
@@ -1599,8 +1599,7 @@ eom_window_open_recent_cb (GtkAction *action, EomWindow *window)
 				       0,
 				       NULL);
 
-	g_slist_foreach (list, (GFunc) g_free, NULL);
-	g_slist_free (list);
+	g_slist_free_full (list, g_free);
 }
 
 static void
@@ -1619,8 +1618,7 @@ file_open_dialog_response_cb (GtkWidget *chooser,
 					       0,
 					       NULL);
 
-		g_slist_foreach (uris, (GFunc) g_free, NULL);
-		g_slist_free (uris);
+		g_slist_free_full (uris, g_free);
 	}
 
 	gtk_widget_destroy (chooser);
@@ -3548,8 +3546,7 @@ eom_window_cmd_move_to_trash (GtkAction *action, gpointer user_data)
 	}
 
 	/* free list */
-	g_list_foreach (images, (GFunc) g_object_unref, NULL);
-	g_list_free (images);
+	g_list_free_full (images, g_object_unref);
 
 	/* select image at previously saved position */
 	pos = MIN (pos, eom_list_store_length (list) - 1);
@@ -4162,8 +4159,7 @@ eom_window_update_recent_files_menu (EomWindow *window)
 		g_free (tip);
 	}
 
-	g_list_foreach (items, (GFunc) gtk_recent_info_unref, NULL);
-	g_list_free (items);
+	g_list_free_full (items, (GDestroyNotify) gtk_recent_info_unref);
 }
 
 static void
@@ -4883,8 +4879,7 @@ eom_window_dispose (GObject *object)
 	}
 
 	if (priv->file_list != NULL) {
-		g_slist_foreach (priv->file_list, (GFunc) g_object_unref, NULL);
-		g_slist_free (priv->file_list);
+		g_slist_free_full (priv->file_list, g_object_unref);
 		priv->file_list = NULL;
 	}
 


### PR DESCRIPTION
Removed warnings (16):
```
egg-editable-toolbar.c:1315:29: warning: cast between incompatible function types from ‘void (*)(GtkWidget *)’ {aka ‘void (*)(struct _GtkWidget *)’} to ‘void (*)(void *, void *)’ [-Wcast-function-type]
 1315 |   g_list_foreach (children, (GFunc) gtk_widget_destroy, NULL);
      |                             ^
--
egg-editable-toolbar.c:1385:33: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
 1385 |       g_list_foreach (children, (GFunc) g_free, NULL);
      |                                 ^
--
eom-window.c:1602:25: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
 1602 |  g_slist_foreach (list, (GFunc) g_free, NULL);
      |                         ^
--
eom-window.c:1622:26: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
 1622 |   g_slist_foreach (uris, (GFunc) g_free, NULL);
      |                          ^
--
eom-window.c:3551:26: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
 3551 |  g_list_foreach (images, (GFunc) g_object_unref, NULL);
      |                          ^
--
eom-window.c:4165:25: warning: cast between incompatible function types from ‘void (*)(GtkRecentInfo *)’ {aka ‘void (*)(struct _GtkRecentInfo *)’} to ‘void (*)(void *, void *)’ [-Wcast-function-type]
 4165 |  g_list_foreach (items, (GFunc) gtk_recent_info_unref, NULL);
      |                         ^
--
eom-window.c:4886:37: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
 4886 |   g_slist_foreach (priv->file_list, (GFunc) g_object_unref, NULL);
      |                                     ^
--
eom-image.c:202:38: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  202 |   g_slist_foreach (priv->undo_stack, (GFunc) g_object_unref, NULL);
      |                                      ^
--
eom-image.c:1652:37: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
 1652 |  g_slist_foreach (priv->undo_stack, (GFunc) g_object_unref, NULL);
      |                                     ^
--
eom-thumb-view.c:859:24: warning: cast between incompatible function types from ‘void (*)(GtkTreePath *)’ {aka ‘void (*)(struct _GtkTreePath *)’} to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  859 |  g_list_foreach (list, (GFunc) gtk_tree_path_free , NULL);
      |                        ^
--
eom-thumb-view.c:986:25: warning: cast between incompatible function types from ‘void (*)(GtkTreePath *)’ {aka ‘void (*)(struct _GtkTreePath *)’} to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  986 |   g_list_foreach (list, (GFunc) gtk_tree_path_free , NULL);
      |                         ^
--
eom-jobs.c:446:33: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  446 |  g_list_foreach (filtered_list, (GFunc) g_object_unref, NULL);
      |                                 ^
eom-jobs.c:449:30: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  449 |  g_list_foreach (error_list, (GFunc) g_free, NULL);
      |                              ^
--
eom-jobs.c:469:31: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  469 |  g_list_foreach (job->images, (GFunc) g_object_unref, NULL);
      |                               ^
--
eom-jobs.c:569:32: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  569 |   g_list_foreach (job->images, (GFunc) g_object_unref, NULL);
      |                                ^
--
eom-uri-converter.c:82:37: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
   82 |   g_list_foreach (priv->token_list, (GFunc) free_token, NULL);
      |                                     ^
```
Not removed warning:
```
--
eom-window.c:5476:30: warning: cast between incompatible function types from ‘void * (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
 5476 |  g_slist_foreach (file_list, (GFunc) g_object_ref, NULL);
      |                              ^
```