### PR TITLE
help: Fix some incongruencies

### DIFF
--- a/help/C/index.docbook
+++ b/help/C/index.docbook
@@ -374,9 +374,9 @@
 	  </listitem>
 	</varlistentry>
 	<varlistentry>
-	  <term>Image Information Pane</term>
+	  <term>Side Pane</term>
 	  <listitem>
-	    <para>The image information pane provides further information about the current image, for example EXIF metadata (if available). It shows up after an image has been loaded. To show or hide the image information pane, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Image Information</guimenuitem></menuchoice> or press <keycombo><keycap>Ctrl</keycap><keycap>I</keycap></keycombo>.</para>
+	    <para>The side pane provides further information about the current image, for example EXIF metadata (if available). It shows up after an image has been loaded. To show or hide the side pane, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Side Pane</guimenuitem></menuchoice> or press <keycap>F9</keycap>.</para>
 	  </listitem>
 	</varlistentry>
   </variablelist>
@@ -482,7 +482,7 @@
 	<section xml:id="eom-fullscreen"><info><title>Viewing an Image Full Screen/Slideshow</title></info>
 		
 		<para>To show the image using the entire screen,  choose <menuchoice><guimenu>View</guimenu><guimenuitem>Full Screen</guimenuitem></menuchoice>.</para>
-		<para>No panels, window frames, or menubars are visible when an image is shown like this. To return to the normal view, press <keycap>Esc</keycap>, or <keycap>F11</keycap>, or <keycombo><keycap>Ctrl</keycap><keycap>W</keycap></keycombo>.</para>
+		<para>No panels, window frames, or menubars are visible when an image is shown like this. To return to the normal view, press <keycap>Esc</keycap>, or <keycap>F11</keycap>.</para>
 		<para>You can zoom or scroll around the image in the same way as when it is shown in a window, using the mouse or the keyboard.</para>
 		<para>If you have multiple images in your collection you can press <keycap>Space</keycap> or use the right/down cursor keys to advance to the next image. The previous image can be reached by pressing <keycap>Backspace</keycap> or using the left/up cursor keys.</para>
 	<para>In this case you can also use the slideshow mode, where <application>Image Viewer</application> automatically switches to the next image in your collection. You can start a slideshow by choosing <menuchoice><guimenu>View</guimenu><guimenuitem>Slideshow</guimenuitem></menuchoice> or by pressing <keycap>F5</keycap>. The slideshow can be paused/continued by pressing <keycap>P</keycap>. To stop the slideshow, press the <keycap>Esc</keycap> or <keycap>F5</keycap> key, or <keycombo><keycap>Ctrl</keycap><keycap>W</keycap></keycombo>. For more information about how to customize the slide show, see <xref linkend="eom-prefs-slideshow"/>. </para>


### PR DESCRIPTION
- It avoids confusing the user by using only one term for the sidepane, and it also fixes its keyboard shortcut.
- Ctrl+W terminates the application.

Test:
```
$ yelp help:eom/eom-whenyoustart
$ yelp help:eom/eom-fullscreen
```