### PR TITLE
eom.desktop: Do not collect the translation for Icon

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -6,7 +6,7 @@ DESKTOP_FILES= $(DESKTOP_IN_FILES:.desktop.in.in=.desktop)
 desktopdir = $(datadir)/applications
 desktop_DATA = $(DESKTOP_FILES)
 $(desktop_DATA): $(DESKTOP_IN_FILES)
-	$(AM_V_GEN) $(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
+	$(AM_V_GEN) $(MSGFMT) --desktop --keyword= --keyword=Name --keyword=Comment --keyword=Keywords --template $< -d $(top_srcdir)/po -o $@
 
 appdatadir = $(datadir)/metainfo
 appdata_in_files = eom.appdata.xml.in


### PR DESCRIPTION
test:
```shell
$ diff data/eom.desktop.master data/eom.desktop
175,186d174
< Icon[ca]=eom
< Icon[cs]=eom
< Icon[da]=eom
< Icon[es]=eom
< Icon[gl]=eom
< Icon[it]=eom
< Icon[lt]=eom
< Icon[ms]=eom
< Icon[nb]=eom
< Icon[nl]=eom
< Icon[uk]=eom
< Icon[zh_TW]=eom
```