### PR TITLE
Travis CI: set compiler warning level to maximum

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -137,8 +137,8 @@ before_scripts:
   - fi
 
 build_scripts:
-  - ./autogen.sh
-  - scan-build $CHECKERS ./configure
+  - ./autogen.sh --enable-compile-warnings=maximum
+  - scan-build $CHECKERS ./configure --enable-compile-warnings=maximum
   - if [ $CPU_COUNT -gt 1 ]; then
   -     scan-build $CHECKERS --keep-cc -o html-report make -j $(( $CPU_COUNT + 1 ))
   - else


### PR DESCRIPTION
I think for stable branches it is sufficient to use default compiler warnings level from eom.
PRs target mostly only master.