### PR TITLE
Add tab scrolling support for GTK3

### DIFF
--- a/src/eom-preferences-dialog.c
+++ b/src/eom-preferences-dialog.c
@@ -46,6 +46,7 @@ struct _EomPreferencesDialogPrivate {
 	GSettings    *ui_settings;
 	GSettings    *fullscreen_settings;
 
+	GtkWidget     *notebook;
 	GtkWidget     *interpolate_check;
 	GtkWidget     *extrapolate_check;
 	GtkWidget     *autorotate_check;
@@ -151,6 +152,9 @@ eom_preferences_dialog_class_init (EomPreferencesDialogClass *klass)
 
 	gtk_widget_class_set_template_from_resource (widget_class,
 	                                             "/org/mate/eom/ui/eom-preferences-dialog.ui");
+	gtk_widget_class_bind_template_child_private (widget_class,
+	                                              EomPreferencesDialog,
+	                                              notebook);
 	gtk_widget_class_bind_template_child_private (widget_class,
 	                                              EomPreferencesDialog,
 	                                              interpolate_check);
@@ -318,6 +322,13 @@ eom_preferences_dialog_init (EomPreferencesDialog *pref_dlg)
 	                 G_SETTINGS_BIND_DEFAULT);
 
 	gtk_widget_show_all (priv->plugin_manager);
+
+    /* Add tab scrolling support for GTK3 */
+    gtk_widget_add_events (priv->notebook, GDK_SCROLL_MASK);
+    g_signal_connect (priv->notebook,
+                      "scroll-event",
+                      G_CALLBACK (eom_util_dialog_page_scroll_event_cb),
+                      NULL);
 }
 
 GtkWidget *eom_preferences_dialog_get_instance (GtkWindow *parent)

--- a/src/eom-properties-dialog.c
+++ b/src/eom-properties-dialog.c
@@ -789,6 +789,13 @@ eom_properties_dialog_init (EomPropertiesDialog *prop_dlg)
 	gtk_notebook_remove_page (GTK_NOTEBOOK (priv->notebook),
 				  EOM_PROPERTIES_DIALOG_PAGE_EXIF);
 #endif
+
+    /* Add tab scrolling support for GTK3 */
+    gtk_widget_add_events (priv->notebook, GDK_SCROLL_MASK);
+    g_signal_connect (priv->notebook,
+                      "scroll-event",
+                      G_CALLBACK (eom_util_dialog_page_scroll_event_cb),
+                      NULL);
 }
 
 /**

--- a/src/eom-util.c
+++ b/src/eom-util.c
@@ -427,3 +427,47 @@ eom_util_show_file_in_filemanager (GFile *file, GtkWindow *toplevel)
 	if (!done)
 		_eom_util_show_file_in_filemanager_fallback (file, toplevel);
 }
+
+gboolean
+eom_util_dialog_page_scroll_event_cb (GtkWidget         *widget,
+                                      GdkEventScroll    *event)
+
+{
+    GtkNotebook *notebook = GTK_NOTEBOOK (widget);
+    GtkWidget *child, *event_widget, *action_widget;
+
+    child = gtk_notebook_get_nth_page (notebook, gtk_notebook_get_current_page (notebook));
+    if (child == NULL)
+        return FALSE;
+
+    event_widget = gtk_get_event_widget ((GdkEvent*) event);
+
+    /* Ignore scroll events from the content of the page */
+    if (event_widget == NULL || event_widget == child || gtk_widget_is_ancestor (event_widget, child))
+        return FALSE;
+
+    /* And also from the action widgets */
+    action_widget = gtk_notebook_get_action_widget (notebook, GTK_PACK_START);
+    if (event_widget == action_widget || (action_widget != NULL && gtk_widget_is_ancestor (event_widget, action_widget)))
+        return FALSE;
+
+    action_widget = gtk_notebook_get_action_widget (notebook, GTK_PACK_END);
+    if (event_widget == action_widget || (action_widget != NULL && gtk_widget_is_ancestor (event_widget, action_widget)))
+        return FALSE;
+
+    switch (event->direction)
+    {
+        case GDK_SCROLL_RIGHT:
+        case GDK_SCROLL_DOWN:
+            gtk_notebook_next_page (notebook);
+            break;
+        case GDK_SCROLL_LEFT:
+        case GDK_SCROLL_UP:
+            gtk_notebook_prev_page (notebook);
+            break;
+        case GDK_SCROLL_SMOOTH:
+        break;
+    }
+
+    return TRUE;
+}

--- a/src/eom-util.h
+++ b/src/eom-util.h
@@ -65,6 +65,9 @@ G_GNUC_INTERNAL
 void     eom_util_show_file_in_filemanager   (GFile *file,
                                               GtkWindow *toplevel);
 
+gboolean eom_util_dialog_page_scroll_event_cb   (GtkWidget      *notebook,
+                                                 GdkEventScroll *event);
+
 G_END_DECLS
 
 #endif /* __EOM_UTIL_H__ */


### PR DESCRIPTION
GTK3 removed the ability to scroll over tabs. This commit re-implements this functionality, while still retaining the feature for GTK2 builds.

Regards.