### PR TITLE
Travis CI: build: drop dbus-glib

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -7,7 +7,6 @@ requires:
     - appstream-glib
     - autoconf-archive
     - clang
-    - dbus-glib
     - exempi
     - gcc
     - git
@@ -34,7 +33,6 @@ requires:
     - git
     - gobject-introspection
     - gtk-doc-tools
-    - libdbus-glib-1-dev
     - libdconf-dev
     - libexempi-dev
     - libexif-dev
@@ -59,7 +57,6 @@ requires:
   fedora:
     # Useful URL: https://src.fedoraproject.org/cgit/rpms/eom.git
     - autoconf-archive
-    - dbus-glib-devel
     - clang
     - clang-analyzer
     - cppcheck-htmlreport
@@ -90,7 +87,6 @@ requires:
     - git
     - gobject-introspection
     - gtk-doc-tools
-    - libdbus-glib-1-dev
     - libdconf-dev
     - libexempi-dev
     - libexif-dev


### PR DESCRIPTION
seems it isn't needed anymore