### PR TITLE
eom-metadata-reader: add gdk/gdk.h include to resolve #258

### DIFF
--- a/src/eom-metadata-reader.c
+++ b/src/eom-metadata-reader.c
@@ -23,6 +23,8 @@
 #include <config.h>
 #endif
 
+#include <gdk/gdk.h>
+
 #include "eom-metadata-reader.h"
 #include "eom-metadata-reader-jpg.h"
 #include "eom-metadata-reader-png.h"


### PR DESCRIPTION
be4fa2808c4e1a36c2c9b58c1267a54cdda6e495, enable wayland support

added "defined(GDK_WINDOWING_x11)" macros without the accompanying gdk
headers

This patch fixes compliation, though I haven't had a chance to dig deep and see what other files also need the header added