### PR TITLE
eom-image: warning -Wexpansion-to-defined

### DIFF
--- a/src/eom-image.c
+++ b/src/eom-image.c
@@ -958,7 +958,7 @@ eom_image_real_load (EomImage *img,
 		}
 
 		if (!strcmp (mime_type, "image/svg+xml")
-#if LIBRSVG_CHECK_FEATURE(SVGZ)
+#if defined (LIBRSVG_HAVE_SVGZ) && LIBRSVG_HAVE_SVGZ
                     || !strcmp (mime_type, "image/svg+xml-compressed")
 #endif
                 ) {


### PR DESCRIPTION
```
eom-image.c:961:1: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
  961 | #if LIBRSVG_CHECK_FEATURE(SVGZ)
      | ^~~~~~~~~~~~~~~~~
```