### PR TITLE
Remove warning -Wshadow

### DIFF
--- a/cut-n-paste/toolbar-editor/egg-editable-toolbar.c
+++ b/cut-n-paste/toolbar-editor/egg-editable-toolbar.c
@@ -468,11 +468,9 @@ configure_item_cursor (GtkToolItem *item,
                 }
               if (icon_name)
                 {
-                  GdkScreen *screen;
                   GtkIconTheme *icon_theme;
                   gint width, height;
 
-                  screen = gtk_widget_get_screen (widget);
                   icon_theme = gtk_icon_theme_get_for_screen (screen);
 
                   if (!gtk_icon_size_lookup (GTK_ICON_SIZE_LARGE_TOOLBAR,
@@ -858,7 +856,7 @@ toolbar_visibility_refresh (EggEditableToolbar *etoolbar)
 {
   EggEditableToolbarPrivate *priv = etoolbar->priv;
   gint n_toolbars, n_items, i, j, k;
-  GtkToggleAction *action;
+  GtkToggleAction *toggle_action;
   GList *list;
   GString *string;
   gboolean showing;
@@ -951,27 +949,28 @@ toolbar_visibility_refresh (EggEditableToolbar *etoolbar)
       if (i >= priv->visibility_actions->len)
         {
           G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
-          action = gtk_toggle_action_new (action_name, action_label, NULL, NULL);
+          toggle_action = gtk_toggle_action_new (action_name, action_label, NULL, NULL);
           G_GNUC_END_IGNORE_DEPRECATIONS;
-          g_ptr_array_add (priv->visibility_actions, action);
-          g_signal_connect_object (action, "toggled",
+          g_ptr_array_add (priv->visibility_actions, toggle_action);
+          g_signal_connect_object (toggle_action, "toggled",
                                    G_CALLBACK (toggled_visibility_cb),
                                    etoolbar, 0);
           G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
-          gtk_action_group_add_action (priv->actions, GTK_ACTION (action));
+          gtk_action_group_add_action (priv->actions, GTK_ACTION (toggle_action));
           G_GNUC_END_IGNORE_DEPRECATIONS;
         }
       else
         {
-	  action = g_ptr_array_index (priv->visibility_actions, i);
-	  g_object_set (action, "label", action_label, NULL);
+	  toggle_action = g_ptr_array_index (priv->visibility_actions, i);
+	  g_object_set (toggle_action, "label", action_label, NULL);
         }
 
       G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
-      gtk_action_set_visible (GTK_ACTION (action), (egg_toolbars_model_get_flags (priv->model, i)
-                                                    & EGG_TB_MODEL_NOT_REMOVABLE) == 0);
-      gtk_action_set_sensitive (GTK_ACTION (action), showing);
-      gtk_toggle_action_set_active (action, gtk_widget_get_visible
+      gtk_action_set_visible (GTK_ACTION (toggle_action),
+                              (egg_toolbars_model_get_flags (priv->model, i)
+                               & EGG_TB_MODEL_NOT_REMOVABLE) == 0);
+      gtk_action_set_sensitive (GTK_ACTION (toggle_action), showing);
+      gtk_toggle_action_set_active (toggle_action, gtk_widget_get_visible
                                     (get_dock_nth (etoolbar, i)));
       G_GNUC_END_IGNORE_DEPRECATIONS;
 
@@ -989,10 +988,10 @@ toolbar_visibility_refresh (EggEditableToolbar *etoolbar)
 
   while (i < priv->visibility_actions->len)
     {
-      action = g_ptr_array_index (priv->visibility_actions, i);
+      toggle_action = g_ptr_array_index (priv->visibility_actions, i);
       g_ptr_array_remove_index_fast (priv->visibility_actions, i);
       G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
-      gtk_action_group_remove_action (priv->actions, GTK_ACTION (action));
+      gtk_action_group_remove_action (priv->actions, GTK_ACTION (toggle_action));
       G_GNUC_END_IGNORE_DEPRECATIONS;
       i++;
     }

--- a/src/eom-image.c
+++ b/src/eom-image.c
@@ -81,8 +81,6 @@ enum {
 
 static guint signals[SIGNAL_LAST] = { 0 };
 
-static GList *supported_mime_types = NULL;
-
 #define EOM_IMAGE_READ_BUFFER_SIZE 65535
 
 static void
@@ -2214,11 +2212,12 @@ compare_quarks (gconstpointer a, gconstpointer b)
 GList *
 eom_image_get_supported_mime_types (void)
 {
+	static GList *supported_mime_types = NULL;
 	GSList *format_list, *it;
 	gchar **mime_types;
 	int i;
 
-	if (!supported_mime_types) {
+	if (supported_mime_types == NULL) {
 		format_list = gdk_pixbuf_get_formats ();
 
 		for (it = format_list; it != NULL; it = it->next) {
@@ -2246,18 +2245,16 @@ eom_image_get_supported_mime_types (void)
 gboolean
 eom_image_is_supported_mime_type (const char *mime_type)
 {
-	GList *supported_mime_types, *result;
+	GList *result;
 	GQuark quark;
 
 	if (mime_type == NULL) {
 		return FALSE;
 	}
 
-	supported_mime_types = eom_image_get_supported_mime_types ();
-
 	quark = g_quark_from_string (mime_type);
 
-	result = g_list_find_custom (supported_mime_types,
+	result = g_list_find_custom (eom_image_get_supported_mime_types (),
 				     GINT_TO_POINTER (quark),
 				     (GCompareFunc) compare_quarks);
 
@@ -2443,4 +2440,3 @@ eom_image_is_jpeg (EomImage *img)
 
 	return ((img->priv->file_type != NULL) && (g_ascii_strcasecmp (img->priv->file_type, EOM_FILE_FORMAT_JPEG) == 0));
 }
-

--- a/src/eom-list-store.c
+++ b/src/eom-list-store.c
@@ -407,8 +407,6 @@ file_monitor_changed_cb (GFileMonitor *monitor,
 		break;
 	case G_FILE_MONITOR_EVENT_DELETED:
 		if (is_file_in_list_store_file (store, file, &iter)) {
-			EomImage *image;
-
 			gtk_tree_model_get (GTK_TREE_MODEL (store), &iter,
 					    EOM_LIST_STORE_EOM_IMAGE, &image,
 					    -1);

--- a/src/eom-window.c
+++ b/src/eom-window.c
@@ -3232,12 +3232,12 @@ eom_window_cmd_wallpaper (GtkAction *action, gpointer user_data)
 	if (filename == NULL || !eom_util_file_is_persistent (file))
 	{
 		GList *files = NULL;
-		GtkAction *action;
+		GtkAction *action_set_as_wp;
 
 		G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
-		action = gtk_action_group_get_action (window->priv->actions_image,
-						      "ImageSetAsWallpaper");
-		gtk_action_set_sensitive (action, FALSE);
+		action_set_as_wp = gtk_action_group_get_action (window->priv->actions_image,
+		                                                "ImageSetAsWallpaper");
+		gtk_action_set_sensitive (action_set_as_wp, FALSE);
 		G_GNUC_END_IGNORE_DEPRECATIONS;
 
 		priv->copy_file_cid = gtk_statusbar_get_context_id (GTK_STATUSBAR (priv->statusbar),


### PR DESCRIPTION
```
egg-editable-toolbar.c:471:30: warning: declaration of 'screen' shadows a previous local [-Wshadow]
  471 |                   GdkScreen *screen;
      |                              ^~~~~~
--
egg-editable-toolbar.c:897:22: warning: declaration of 'action' shadows a previous local [-Wshadow]
  897 |           GtkAction *action;
      |                      ^~~~~~
--
eom-window.c:3235:14: warning: declaration of 'action' shadows a parameter [-Wshadow]
 3235 |   GtkAction *action;
      |              ^~~~~~
--
eom-image.c:2249:9: warning: declaration of 'supported_mime_types' shadows a global declaration [-Wshadow]
 2249 |  GList *supported_mime_types, *result;
      |         ^~~~~~~~~~~~~~~~~~~~
--
eom-list-store.c:410:14: warning: declaration of 'image' shadows a previous local [-Wshadow]
  410 |    EomImage *image;
      |              ^~~~~
```