### PR TITLE
eom-uri-converter: dereference of NULL 'repl_str' reported by gcc

### DIFF
--- a/src/eom-uri-converter.c
+++ b/src/eom-uri-converter.c
@@ -794,7 +794,7 @@ eom_uri_converter_do (EomURIConverter *conv, EomImage *image,
 
 	repl_str = replace_remove_chars (str, priv->convert_spaces, priv->space_character);
 
-	if (repl_str->len > 0) {
+	if ((repl_str != NULL) && (repl_str->len > 0)) {
 		build_absolute_file (conv, image, repl_str, file, format);
 	}
 


### PR DESCRIPTION
test
```
$ CFLAGS="-g -O0 -fanalyzer" LDFLAGS="-fanalyzer" ./autogen.sh --enable-debug && make &> make.log
$ diff make-master.log make.log
```
```
< eom-uri-converter.c: In function 'eom_uri_converter_do':
< eom-uri-converter.c:797:14: warning: dereference of NULL 'repl_str' [CWE-690] [-Wanalyzer-null-dereference]
<   797 |  if (repl_str->len > 0) {
<       |      ~~~~~~~~^~~~~
<   'eom_uri_converter_do': event 1
<     |
<     |  721 | eom_uri_converter_do (EomURIConverter *conv, EomImage *image,
<     |      | ^~~~~~~~~~~~~~~~~~~~
<     |      | |
<     |      | (1) entry to 'eom_uri_converter_do'
<     |
<   'eom_uri_converter_do': event 2
<     |
<     |eom-uri-converter.h:10:42:
<     |   10 | #define EOM_TYPE_URI_CONVERTER          (eom_uri_converter_get_type ())
< /usr/include/glib-2.0/glib/gmacros.h:939:25: note: in definition of macro 'G_LIKELY'
<     |  939 | #define G_LIKELY(expr) (expr)
<     |      |                         ^~~~
< eom-uri-converter.c:729:2: note: in expansion of macro 'g_return_val_if_fail'
<     |  729 |  g_return_val_if_fail (EOM_IS_URI_CONVERTER (conv), FALSE);
<     |      |  ^~~~~~~~~~~~~~~~~~~~
< /usr/include/glib-2.0/gobject/gtype.h:497:66: note: in expansion of macro '_G_TYPE_CIT'
<     |  497 | #define G_TYPE_CHECK_INSTANCE_TYPE(instance, g_type)            (_G_TYPE_CIT ((instance), (g_type)))
<     |      |                                                                  ^~~~~~~~~~~
< eom-uri-converter.h:13:42: note: in expansion of macro 'G_TYPE_CHECK_INSTANCE_TYPE'
<     |   13 | #define EOM_IS_URI_CONVERTER(o)         (G_TYPE_CHECK_INSTANCE_TYPE ((o), EOM_TYPE_URI_CONVERTER))
<     |      |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~
< eom-uri-converter.h:13:75: note: in expansion of macro 'EOM_TYPE_URI_CONVERTER'
<     |   13 | #define EOM_IS_URI_CONVERTER(o)         (G_TYPE_CHECK_INSTANCE_TYPE ((o), EOM_TYPE_URI_CONVERTER))
<     |      |                                                                           ^~~~~~~~~~~~~~~~~~~~~~
< eom-uri-converter.c:729:24: note: in expansion of macro 'EOM_IS_URI_CONVERTER'
<     |  729 |  g_return_val_if_fail (EOM_IS_URI_CONVERTER (conv), FALSE);
<     |      |                        ^~~~~~~~~~~~~~~~~~~~
<     |
<     +--> 'eom_uri_converter_get_type': event 3
<            |
<            |   54 | G_DEFINE_TYPE_WITH_PRIVATE (EomURIConverter, eom_uri_converter, G_TYPE_OBJECT)
<            |      |                                              ^~~~~~~~~~~~~~~~~
<            |      |                                              |
<            |      |                                              (3) entry to 'eom_uri_converter_get_type'
< /usr/include/glib-2.0/gobject/gtype.h:1993:1: note: in definition of macro '_G_DEFINE_TYPE_EXTENDED_BEGIN_PRE'
<            | 1993 | type_name##_get_type (void) \
<            |      | ^~~~~~~~~
< /usr/include/glib-2.0/gobject/gtype.h:1759:60: note: in expansion of macro '_G_DEFINE_TYPE_EXTENDED_BEGIN'
<            | 1759 | #define G_DEFINE_TYPE_EXTENDED(TN, t_n, T_P, _f_, _C_)     _G_DEFINE_TYPE_EXTENDED_BEGIN (TN, t_n, T_P, _f_) {_C_;} _G_DEFINE_TYPE_EXTENDED_END()
<            |      |                                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /usr/include/glib-2.0/gobject/gtype.h:1640:61: note: in expansion of macro 'G_DEFINE_TYPE_EXTENDED'
<            | 1640 | #define G_DEFINE_TYPE_WITH_PRIVATE(TN, t_n, T_P)            G_DEFINE_TYPE_EXTENDED (TN, t_n, T_P, 0, G_ADD_PRIVATE (TN))
<            |      |                                                             ^~~~~~~~~~~~~~~~~~~~~~
< eom-uri-converter.c:54:1: note: in expansion of macro 'G_DEFINE_TYPE_WITH_PRIVATE'
<            |   54 | G_DEFINE_TYPE_WITH_PRIVATE (EomURIConverter, eom_uri_converter, G_TYPE_OBJECT)
<            |      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
<            |
<          'eom_uri_converter_get_type': event 4
<            |
<            |/usr/include/glib-2.0/glib/gthread.h:260:39:
<            |  260 |     (!g_atomic_pointer_get (location) &&                             \
<            |      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<            |      |                                       |
<            |      |                                       (4) following 'true' branch...
<            |  261 |      g_once_init_enter (location));                                  \
<            |      |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~     
< /usr/include/glib-2.0/gobject/gtype.h:2000:7: note: in expansion of macro 'g_once_init_enter'
<            | 2000 |   if (g_once_init_enter (&g_define_type_id__volatile))  \
<            |      |       ^~~~~~~~~~~~~~~~~
< /usr/include/glib-2.0/gobject/gtype.h:2032:3: note: in expansion of macro '_G_DEFINE_TYPE_EXTENDED_BEGIN_REGISTER'
<            | 2032 |   _G_DEFINE_TYPE_EXTENDED_BEGIN_REGISTER(TypeName, type_name, TYPE_PARENT, flags) \
<            |      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /usr/include/glib-2.0/gobject/gtype.h:1759:60: note: in expansion of macro '_G_DEFINE_TYPE_EXTENDED_BEGIN'
<            | 1759 | #define G_DEFINE_TYPE_EXTENDED(TN, t_n, T_P, _f_, _C_)     _G_DEFINE_TYPE_EXTENDED_BEGIN (TN, t_n, T_P, _f_) {_C_;} _G_DEFINE_TYPE_EXTENDED_END()
<            |      |                                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /usr/include/glib-2.0/gobject/gtype.h:1640:61: note: in expansion of macro 'G_DEFINE_TYPE_EXTENDED'
<            | 1640 | #define G_DEFINE_TYPE_WITH_PRIVATE(TN, t_n, T_P)            G_DEFINE_TYPE_EXTENDED (TN, t_n, T_P, 0, G_ADD_PRIVATE (TN))
<            |      |                                                             ^~~~~~~~~~~~~~~~~~~~~~
< eom-uri-converter.c:54:1: note: in expansion of macro 'G_DEFINE_TYPE_WITH_PRIVATE'
<            |   54 | G_DEFINE_TYPE_WITH_PRIVATE (EomURIConverter, eom_uri_converter, G_TYPE_OBJECT)
<            |      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
<            |
<          'eom_uri_converter_get_type': event 5
<            |
<            |/usr/include/glib-2.0/glib/gthread.h:261:6:
<            |  261 |      g_once_init_enter (location));                                  \
<            |      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
<            |      |      |
<            |      |      (5) ...to here
< /usr/include/glib-2.0/gobject/gtype.h:2000:7: note: in expansion of macro 'g_once_init_enter'
<            | 2000 |   if (g_once_init_enter (&g_define_type_id__volatile))  \
<            |      |       ^~~~~~~~~~~~~~~~~
< /usr/include/glib-2.0/gobject/gtype.h:2032:3: note: in expansion of macro '_G_DEFINE_TYPE_EXTENDED_BEGIN_REGISTER'
<            | 2032 |   _G_DEFINE_TYPE_EXTENDED_BEGIN_REGISTER(TypeName, type_name, TYPE_PARENT, flags) \
<            |      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /usr/include/glib-2.0/gobject/gtype.h:1759:60: note: in expansion of macro '_G_DEFINE_TYPE_EXTENDED_BEGIN'
<            | 1759 | #define G_DEFINE_TYPE_EXTENDED(TN, t_n, T_P, _f_, _C_)     _G_DEFINE_TYPE_EXTENDED_BEGIN (TN, t_n, T_P, _f_) {_C_;} _G_DEFINE_TYPE_EXTENDED_END()
<            |      |                                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /usr/include/glib-2.0/gobject/gtype.h:1640:61: note: in expansion of macro 'G_DEFINE_TYPE_EXTENDED'
<            | 1640 | #define G_DEFINE_TYPE_WITH_PRIVATE(TN, t_n, T_P)            G_DEFINE_TYPE_EXTENDED (TN, t_n, T_P, 0, G_ADD_PRIVATE (TN))
<            |      |                                                             ^~~~~~~~~~~~~~~~~~~~~~
< eom-uri-converter.c:54:1: note: in expansion of macro 'G_DEFINE_TYPE_WITH_PRIVATE'
<            |   54 | G_DEFINE_TYPE_WITH_PRIVATE (EomURIConverter, eom_uri_converter, G_TYPE_OBJECT)
<            |      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
<            |
<          'eom_uri_converter_get_type': event 6
<            |
<            |/usr/include/glib-2.0/glib/gthread.h:260:39:
<            |  260 |     (!g_atomic_pointer_get (location) &&                             \
<            |      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<            |      |                                       |
<            |      |                                       (6) following 'true' branch...
<            |  261 |      g_once_init_enter (location));                                  \
<            |      |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~     
< /usr/include/glib-2.0/gobject/gtype.h:2000:7: note: in expansion of macro 'g_once_init_enter'
<            | 2000 |   if (g_once_init_enter (&g_define_type_id__volatile))  \
<            |      |       ^~~~~~~~~~~~~~~~~
< /usr/include/glib-2.0/gobject/gtype.h:2032:3: note: in expansion of macro '_G_DEFINE_TYPE_EXTENDED_BEGIN_REGISTER'
<            | 2032 |   _G_DEFINE_TYPE_EXTENDED_BEGIN_REGISTER(TypeName, type_name, TYPE_PARENT, flags) \
<            |      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /usr/include/glib-2.0/gobject/gtype.h:1759:60: note: in expansion of macro '_G_DEFINE_TYPE_EXTENDED_BEGIN'
<            | 1759 | #define G_DEFINE_TYPE_EXTENDED(TN, t_n, T_P, _f_, _C_)     _G_DEFINE_TYPE_EXTENDED_BEGIN (TN, t_n, T_P, _f_) {_C_;} _G_DEFINE_TYPE_EXTENDED_END()
<            |      |                                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /usr/include/glib-2.0/gobject/gtype.h:1640:61: note: in expansion of macro 'G_DEFINE_TYPE_EXTENDED'
<            | 1640 | #define G_DEFINE_TYPE_WITH_PRIVATE(TN, t_n, T_P)            G_DEFINE_TYPE_EXTENDED (TN, t_n, T_P, 0, G_ADD_PRIVATE (TN))
<            |      |                                                             ^~~~~~~~~~~~~~~~~~~~~~
< eom-uri-converter.c:54:1: note: in expansion of macro 'G_DEFINE_TYPE_WITH_PRIVATE'
<            |   54 | G_DEFINE_TYPE_WITH_PRIVATE (EomURIConverter, eom_uri_converter, G_TYPE_OBJECT)
<            |      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
<            |
<          'eom_uri_converter_get_type': event 7
<            |
<            |/usr/include/glib-2.0/glib/gthread.h:260:39:
<            |  260 |     (!g_atomic_pointer_get (location) &&                             \
<            |      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<            |      |                                       |
<            |      |                                       (7) ...to here
<            |  261 |      g_once_init_enter (location));                                  \
<            |      |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~     
< /usr/include/glib-2.0/gobject/gtype.h:2000:7: note: in expansion of macro 'g_once_init_enter'
<            | 2000 |   if (g_once_init_enter (&g_define_type_id__volatile))  \
<            |      |       ^~~~~~~~~~~~~~~~~
< /usr/include/glib-2.0/gobject/gtype.h:2032:3: note: in expansion of macro '_G_DEFINE_TYPE_EXTENDED_BEGIN_REGISTER'
<            | 2032 |   _G_DEFINE_TYPE_EXTENDED_BEGIN_REGISTER(TypeName, type_name, TYPE_PARENT, flags) \
<            |      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /usr/include/glib-2.0/gobject/gtype.h:1759:60: note: in expansion of macro '_G_DEFINE_TYPE_EXTENDED_BEGIN'
<            | 1759 | #define G_DEFINE_TYPE_EXTENDED(TN, t_n, T_P, _f_, _C_)     _G_DEFINE_TYPE_EXTENDED_BEGIN (TN, t_n, T_P, _f_) {_C_;} _G_DEFINE_TYPE_EXTENDED_END()
<            |      |                                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /usr/include/glib-2.0/gobject/gtype.h:1640:61: note: in expansion of macro 'G_DEFINE_TYPE_EXTENDED'
<            | 1640 | #define G_DEFINE_TYPE_WITH_PRIVATE(TN, t_n, T_P)            G_DEFINE_TYPE_EXTENDED (TN, t_n, T_P, 0, G_ADD_PRIVATE (TN))
<            |      |                                                             ^~~~~~~~~~~~~~~~~~~~~~
< eom-uri-converter.c:54:1: note: in expansion of macro 'G_DEFINE_TYPE_WITH_PRIVATE'
<            |   54 | G_DEFINE_TYPE_WITH_PRIVATE (EomURIConverter, eom_uri_converter, G_TYPE_OBJECT)
<            |      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
<            |
<          'eom_uri_converter_get_type': event 8
<            |
<            |/usr/include/glib-2.0/gobject/gtype.h:2000:6:
<            | 2000 |   if (g_once_init_enter (&g_define_type_id__volatile))  \
<            |      |      ^
<            |      |      |
<            |      |      (8) following 'true' branch...
< /usr/include/glib-2.0/gobject/gtype.h:2032:3: note: in expansion of macro '_G_DEFINE_TYPE_EXTENDED_BEGIN_REGISTER'
<            | 2032 |   _G_DEFINE_TYPE_EXTENDED_BEGIN_REGISTER(TypeName, type_name, TYPE_PARENT, flags) \
<            |      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /usr/include/glib-2.0/gobject/gtype.h:1759:60: note: in expansion of macro '_G_DEFINE_TYPE_EXTENDED_BEGIN'
<            | 1759 | #define G_DEFINE_TYPE_EXTENDED(TN, t_n, T_P, _f_, _C_)     _G_DEFINE_TYPE_EXTENDED_BEGIN (TN, t_n, T_P, _f_) {_C_;} _G_DEFINE_TYPE_EXTENDED_END()
<            |      |                                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /usr/include/glib-2.0/gobject/gtype.h:1640:61: note: in expansion of macro 'G_DEFINE_TYPE_EXTENDED'
<            | 1640 | #define G_DEFINE_TYPE_WITH_PRIVATE(TN, t_n, T_P)            G_DEFINE_TYPE_EXTENDED (TN, t_n, T_P, 0, G_ADD_PRIVATE (TN))
<            |      |                                                             ^~~~~~~~~~~~~~~~~~~~~~
< eom-uri-converter.c:54:1: note: in expansion of macro 'G_DEFINE_TYPE_WITH_PRIVATE'
<            |   54 | G_DEFINE_TYPE_WITH_PRIVATE (EomURIConverter, eom_uri_converter, G_TYPE_OBJECT)
<            |      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
<            |
<          'eom_uri_converter_get_type': event 9
<            |
<            |   54 | G_DEFINE_TYPE_WITH_PRIVATE (EomURIConverter, eom_uri_converter, G_TYPE_OBJECT)
< /usr/include/glib-2.0/gobject/gtype.h:2002:32: note: in definition of macro '_G_DEFINE_TYPE_EXTENDED_BEGIN_REGISTER'
<            | 2002 |       GType g_define_type_id = type_name##_get_type_once (); \
<            |      |                                ^~~~~~~~~
< /usr/include/glib-2.0/gobject/gtype.h:1759:60: note: in expansion of macro '_G_DEFINE_TYPE_EXTENDED_BEGIN'
<            | 1759 | #define G_DEFINE_TYPE_EXTENDED(TN, t_n, T_P, _f_, _C_)     _G_DEFINE_TYPE_EXTENDED_BEGIN (TN, t_n, T_P, _f_) {_C_;} _G_DEFINE_TYPE_EXTENDED_END()
<            |      |                                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /usr/include/glib-2.0/gobject/gtype.h:1640:61: note: in expansion of macro 'G_DEFINE_TYPE_EXTENDED'
<            | 1640 | #define G_DEFINE_TYPE_WITH_PRIVATE(TN, t_n, T_P)            G_DEFINE_TYPE_EXTENDED (TN, t_n, T_P, 0, G_ADD_PRIVATE (TN))
<            |      |                                                             ^~~~~~~~~~~~~~~~~~~~~~
< eom-uri-converter.c:54:1: note: in expansion of macro 'G_DEFINE_TYPE_WITH_PRIVATE'
<            |   54 | G_DEFINE_TYPE_WITH_PRIVATE (EomURIConverter, eom_uri_converter, G_TYPE_OBJECT)
<            |      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
<            |
<     <------+
<     |
<   'eom_uri_converter_do': event 10
<     |
<     |eom-uri-converter.h:10:42:
<     |   10 | #define EOM_TYPE_URI_CONVERTER          (eom_uri_converter_get_type ())
< /usr/include/glib-2.0/glib/gmacros.h:939:25: note: in definition of macro 'G_LIKELY'
<     |  939 | #define G_LIKELY(expr) (expr)
<     |      |                         ^~~~
< eom-uri-converter.c:729:2: note: in expansion of macro 'g_return_val_if_fail'
<     |  729 |  g_return_val_if_fail (EOM_IS_URI_CONVERTER (conv), FALSE);
<     |      |  ^~~~~~~~~~~~~~~~~~~~
< /usr/include/glib-2.0/gobject/gtype.h:497:66: note: in expansion of macro '_G_TYPE_CIT'
<     |  497 | #define G_TYPE_CHECK_INSTANCE_TYPE(instance, g_type)            (_G_TYPE_CIT ((instance), (g_type)))
<     |      |                                                                  ^~~~~~~~~~~
< eom-uri-converter.h:13:42: note: in expansion of macro 'G_TYPE_CHECK_INSTANCE_TYPE'
<     |   13 | #define EOM_IS_URI_CONVERTER(o)         (G_TYPE_CHECK_INSTANCE_TYPE ((o), EOM_TYPE_URI_CONVERTER))
<     |      |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~
< eom-uri-converter.h:13:75: note: in expansion of macro 'EOM_TYPE_URI_CONVERTER'
<     |   13 | #define EOM_IS_URI_CONVERTER(o)         (G_TYPE_CHECK_INSTANCE_TYPE ((o), EOM_TYPE_URI_CONVERTER))
<     |      |                                                                           ^~~~~~~~~~~~~~~~~~~~~~
< eom-uri-converter.c:729:24: note: in expansion of macro 'EOM_IS_URI_CONVERTER'
<     |  729 |  g_return_val_if_fail (EOM_IS_URI_CONVERTER (conv), FALSE);
<     |      |                        ^~~~~~~~~~~~~~~~~~~~
<     |
<   'eom_uri_converter_do': event 11
<     |
<     |/usr/include/glib-2.0/gobject/gtype.h:2312:6:
<     | 2312 |   if (!__inst) \
<     |      |      ^
<     |      |      |
<     |      |      (11) following 'false' branch (when '__inst' is non-NULL)...
< /usr/include/glib-2.0/glib/gmacros.h:939:25: note: in definition of macro 'G_LIKELY'
<     |  939 | #define G_LIKELY(expr) (expr)
<     |      |                         ^~~~
< eom-uri-converter.c:729:2: note: in expansion of macro 'g_return_val_if_fail'
<     |  729 |  g_return_val_if_fail (EOM_IS_URI_CONVERTER (conv), FALSE);
<     |      |  ^~~~~~~~~~~~~~~~~~~~
< /usr/include/glib-2.0/gobject/gtype.h:497:66: note: in expansion of macro '_G_TYPE_CIT'
<     |  497 | #define G_TYPE_CHECK_INSTANCE_TYPE(instance, g_type)            (_G_TYPE_CIT ((instance), (g_type)))
<     |      |                                                                  ^~~~~~~~~~~
< eom-uri-converter.h:13:42: note: in expansion of macro 'G_TYPE_CHECK_INSTANCE_TYPE'
<     |   13 | #define EOM_IS_URI_CONVERTER(o)         (G_TYPE_CHECK_INSTANCE_TYPE ((o), EOM_TYPE_URI_CONVERTER))
<     |      |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~
< eom-uri-converter.c:729:24: note: in expansion of macro 'EOM_IS_URI_CONVERTER'
<     |  729 |  g_return_val_if_fail (EOM_IS_URI_CONVERTER (conv), FALSE);
<     |      |                        ^~~~~~~~~~~~~~~~~~~~
<     |
<   'eom_uri_converter_do': event 12
<     |
<     |/usr/include/glib-2.0/gobject/gtype.h:2314:18:
<     | 2314 |   else if (__inst->g_class && __inst->g_class->g_type == __t) \
<     |      |            ~~~~~~^~~~~~~~~
<     |      |                  |
<     |      |                  (12) ...to here
< /usr/include/glib-2.0/glib/gmacros.h:939:25: note: in definition of macro 'G_LIKELY'
<     |  939 | #define G_LIKELY(expr) (expr)
<     |      |                         ^~~~
< eom-uri-converter.c:729:2: note: in expansion of macro 'g_return_val_if_fail'
<     |  729 |  g_return_val_if_fail (EOM_IS_URI_CONVERTER (conv), FALSE);
<     |      |  ^~~~~~~~~~~~~~~~~~~~
< /usr/include/glib-2.0/gobject/gtype.h:497:66: note: in expansion of macro '_G_TYPE_CIT'
<     |  497 | #define G_TYPE_CHECK_INSTANCE_TYPE(instance, g_type)            (_G_TYPE_CIT ((instance), (g_type)))
<     |      |                                                                  ^~~~~~~~~~~
< eom-uri-converter.h:13:42: note: in expansion of macro 'G_TYPE_CHECK_INSTANCE_TYPE'
<     |   13 | #define EOM_IS_URI_CONVERTER(o)         (G_TYPE_CHECK_INSTANCE_TYPE ((o), EOM_TYPE_URI_CONVERTER))
<     |      |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~
< eom-uri-converter.c:729:24: note: in expansion of macro 'EOM_IS_URI_CONVERTER'
<     |  729 |  g_return_val_if_fail (EOM_IS_URI_CONVERTER (conv), FALSE);
<     |      |                        ^~~~~~~~~~~~~~~~~~~~
<     |
<   'eom_uri_converter_do': event 13
<     |
<     |/usr/include/glib-2.0/glib/gmessages.h:637:8:
<     |  637 |     if (G_LIKELY (expr)) \
<     |      |        ^
<     |      |        |
<     |      |        (13) following 'true' branch...
< eom-uri-converter.c:729:2: note: in expansion of macro 'g_return_val_if_fail'
<     |  729 |  g_return_val_if_fail (EOM_IS_URI_CONVERTER (conv), FALSE);
<     |      |  ^~~~~~~~~~~~~~~~~~~~
<     |
<   'eom_uri_converter_do': events 14-19
<     |
<     |  731 |  priv = conv->priv;
<     |      |  ~~~~~^~~~~~~~~~~~
<     |      |       |
<     |      |       (14) ...to here
<     |......
<     |  734 |  if (format != NULL)
<     |      |     ~  
<     |      |     |
<     |      |     (15) following 'false' branch (when 'format' is NULL)...
<     |......
<     |  737 |  str = g_string_new ("");
<     |      |        ~~~~~~~~~~~~~~~~~
<     |      |        |
<     |      |        (16) ...to here
<     |  738 | 
<     |  739 |  for (it = priv->token_list; it != NULL; it = it->next) {
<     |      |  ~~~   
<     |      |  |
<     |      |  (17) following 'false' branch (when 'it' is NULL)...
<     |......
<     |  795 |  repl_str = replace_remove_chars (str, priv->convert_spaces, priv->space_character);
<     |      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<     |      |             |                                                    |
<     |      |             |                                                    (18) ...to here
<     |      |             (19) calling 'replace_remove_chars' from 'eom_uri_converter_do'
<     |
<     +--> 'replace_remove_chars': event 20
<            |
<            |  676 | replace_remove_chars (GString *str, gboolean convert_spaces, gunichar space_char)
<            |      | ^~~~~~~~~~~~~~~~~~~~
<            |      | |
<            |      | (20) entry to 'replace_remove_chars'
<            |
<          'replace_remove_chars': event 21
<            |
<            |/usr/include/glib-2.0/glib/gmessages.h:637:8:
<            |  637 |     if (G_LIKELY (expr)) \
<            |      |        ^
<            |      |        |
<            |      |        (21) following 'false' branch (when 'str' is NULL)...
< eom-uri-converter.c:684:2: note: in expansion of macro 'g_return_val_if_fail'
<            |  684 |  g_return_val_if_fail (str != NULL, NULL);
<            |      |  ^~~~~~~~~~~~~~~~~~~~
<            |
<          'replace_remove_chars': event 22
<            |
<            |/usr/include/glib-2.0/glib/gmessages.h:641:9:
<            |  641 |         g_return_if_fail_warning (G_LOG_DOMAIN, \
<            |      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<            |      |         |
<            |      |         (22) ...to here
<            |  642 |                                   G_STRFUNC, \
<            |      |                                   ~~~~~~~~~~~~
<            |  643 |                                   #expr); \
<            |      |                                   ~~~~~~
< eom-uri-converter.c:684:2: note: in expansion of macro 'g_return_val_if_fail'
<            |  684 |  g_return_val_if_fail (str != NULL, NULL);
<            |      |  ^~~~~~~~~~~~~~~~~~~~
<            |
<          'replace_remove_chars': event 23
<            |
<            |cc1:
<            | (23): '<return-value>' is NULL
<            |
<     <------+
<     |
<   'eom_uri_converter_do': events 24-25
<     |
<     |  795 |  repl_str = replace_remove_chars (str, priv->convert_spaces, priv->space_character);
<     |      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<     |      |             |
<     |      |             (24) return of NULL to 'eom_uri_converter_do' from 'replace_remove_chars'
<     |  796 | 
<     |  797 |  if (repl_str->len > 0) {
<     |      |      ~~~~~~~~~~~~~
<     |      |              |
<     |      |              (25) dereference of NULL 'repl_str'
<     |
```