### PR TITLE
Remove cppcheck warning knownConditionTrueFalse

### DIFF
--- a/cut-n-paste/toolbar-editor/egg-editable-toolbar.c
+++ b/cut-n-paste/toolbar-editor/egg-editable-toolbar.c
@@ -1108,12 +1108,14 @@ static void
 update_fixed (EggEditableToolbar *etoolbar)
 {
   GtkWidget *toolbar, *dock;
-  if (!etoolbar->priv->fixed_toolbar) return;
+
+  if (!etoolbar->priv->fixed_toolbar)
+    return;
 
   toolbar = etoolbar->priv->fixed_toolbar;
   dock = get_dock_nth (etoolbar, 0);
 
-  if (dock && toolbar && gtk_widget_get_parent (toolbar) == NULL)
+  if (dock && gtk_widget_get_parent (toolbar) == NULL)
     {
       gtk_box_pack_end (GTK_BOX (dock), toolbar, FALSE, TRUE, 0);
 

--- a/src/eom-file-chooser.c
+++ b/src/eom-file-chooser.c
@@ -379,9 +379,7 @@ update_preview_cb (GtkFileChooser *file_chooser, gpointer data)
 			set_preview_pixbuf (EOM_FILE_CHOOSER (file_chooser), pixbuf,
 					    g_file_info_get_size (file_info));
 
-			if (pixbuf != NULL) {
-				g_object_unref (pixbuf);
-			}
+			g_object_unref (pixbuf);
 		}
 	}
 

--- a/src/eom-image.c
+++ b/src/eom-image.c
@@ -1952,7 +1952,7 @@ eom_image_get_caption (EomImage *img)
 				/* Guaranteed to be correct utf8 here */
 				validated = TRUE;
 			}
-		} else if (!broken_filenames) {
+		} else {
 			/* name was valid, no need to re-validate */
 			validated = TRUE;
 		}


### PR DESCRIPTION
```
cut-n-paste/toolbar-editor/egg-editable-toolbar.c:1116:15: style: Condition 'toolbar' is always true [knownConditionTrueFalse]
  if (dock && toolbar && gtk_widget_get_parent (toolbar) == NULL)
              ^
cut-n-paste/toolbar-editor/egg-editable-toolbar.c:1111:7: note: Assuming that condition '!etoolbar->priv->fixed_toolbar' is not redundant
  if (!etoolbar->priv->fixed_toolbar) return;
      ^
cut-n-paste/toolbar-editor/egg-editable-toolbar.c:1113:27: note: Assignment 'toolbar=etoolbar->priv->fixed_toolbar', assigned value is 0
  toolbar = etoolbar->priv->fixed_toolbar;
                          ^
cut-n-paste/toolbar-editor/egg-editable-toolbar.c:1116:15: note: Condition 'toolbar' is always true
  if (dock && toolbar && gtk_widget_get_parent (toolbar) == NULL)
              ^
```
```
src/eom-file-chooser.c:382:15: style: Condition 'pixbuf!=NULL' is always true [knownConditionTrueFalse]
   if (pixbuf != NULL) {
              ^
src/eom-file-chooser.c:376:14: note: Assuming that condition 'pixbuf!=NULL' is not redundant
  if (pixbuf != NULL) {
             ^
src/eom-file-chooser.c:382:15: note: Condition 'pixbuf!=NULL' is always true
   if (pixbuf != NULL) {
              ^
```
```
src/eom-image.c:1955:14: style: Condition '!broken_filenames' is always true [knownConditionTrueFalse]
  } else if (!broken_filenames) {
             ^
src/eom-image.c:1947:7: note: Assuming that condition 'broken_filenames' is not redundant
  if (broken_filenames || !g_utf8_validate (name, -1, NULL)) {
      ^
src/eom-image.c:1955:14: note: Condition '!broken_filenames' is always true
  } else if (!broken_filenames) {
             ^
```