### PR TITLE
build: allow users to disable gettext support (--disable-nls)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,10 +1,14 @@
 ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 
+if USE_NLS
+PO_SUBDIR = po
+endif
+
 if ENABLE_JPEG
 jpeg_DIRS = jpegutils
 endif
 
-SUBDIRS = po $(jpeg_DIRS) cut-n-paste src man plugins help data doc
+SUBDIRS = $(PO_SUBDIR) $(jpeg_DIRS) cut-n-paste src man plugins help data doc
 
 if ENABLE_THUMBNAILER
 SUBDIRS += thumbnailer

--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,10 @@ GTK_DOC_CHECK(1.9)
 
 AC_CHECK_FUNCS(strptime)
 
+GETTEXT_PACKAGE=AC_PACKAGE_NAME
+AC_SUBST(GETTEXT_PACKAGE)
+AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE, "$GETTEXT_PACKAGE", [Gettext package.])
+
 # ****************************************************************
 # Support for nl_langinfo (_NL_MEASUREMENT_MEASUREMENT) (optional)
 # ****************************************************************
@@ -62,13 +66,9 @@ fi
 # ***********
 # Translation
 # ***********
-AM_GNU_GETTEXT_VERSION([0.19.8])
-AM_GNU_GETTEXT_REQUIRE_VERSION([0.19.8])
 AM_GNU_GETTEXT([external])
-
-GETTEXT_PACKAGE=AC_PACKAGE_NAME
-AC_SUBST(GETTEXT_PACKAGE)
-AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE, "$GETTEXT_PACKAGE", [Gettext package.])
+AM_GNU_GETTEXT_VERSION([0.19.8])
+AM_CONDITIONAL([USE_NLS], [test "x${USE_NLS}" = "xyes"])
 
 AC_SUBST(CFLAGS)
 AC_SUBST(LDFLAGS)
@@ -429,5 +429,6 @@ Configure summary:
 	RSVG support ...............:  ${have_rsvg}
 	Colour management support ..:  ${have_lcms}
 	GObject Introspection.......:  ${have_introspection}
+	Gettext support.............:  ${USE_NLS}
 	Thumbnailer.................:  ${eom_thumbnailer}
 "

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -4,15 +4,25 @@ desktopdir = $(datadir)/applications
 desktop_DATA = eom.desktop
 desktop_in_files = $(desktop_DATA:.desktop=.desktop.in)
 desktop_in_in_files = $(desktop_in_files:.desktop.in=.desktop.in.in)
+
 $(desktop_DATA): $(desktop_in_files)
+if USE_NLS
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword= --keyword=Name --keyword=Comment --keyword=Keywords --template $< -d $(top_srcdir)/po -o $@
+else
+	$(AM_V_GEN) cp $< $@
+endif
 
 appdatadir = $(datadir)/metainfo
 appdata_DATA = eom.appdata.xml
 appdata_in_files = $(appdata_DATA:.xml=.xml.in)
 appdata_in_in_files = $(appdata_in_files:.xml.in=.xml.in.in)
+
 $(appdata_DATA): $(appdata_in_files)
+if USE_NLS
 	$(AM_V_GEN) $(MSGFMT) --xml --template $< -d $(top_srcdir)/po -o $@
+else
+	$(AM_V_GEN) cp $< $@
+endif
 
 gsettings_ENUM_NAMESPACE = org.mate.eom
 gsettings_ENUM_FILES = $(top_srcdir)/src/eom-scroll-view.h	\

--- a/help/Makefile.am
+++ b/help/Makefile.am
@@ -7,10 +7,14 @@ HELP_MEDIA = 					\
 	figures/eom_start_window.png		\
 	figures/eom_toolbar_editor_window.png
 
+if USE_NLS
 # Add linguas to be ignored, e.g. IGNORE_HELP_LINGUAS = ca de es fr
 IGNORE_HELP_LINGUAS =
 HELP_LINGUAS = $(if $(IGNORE_HELP_LINGUAS), \
 	$(filter-out $(IGNORE_HELP_LINGUAS),$(subst /,,$(dir $(wildcard */*.po)))), \
 	$(subst /,,$(dir $(wildcard */*.po))) )
+else
+HELP_LINGUAS =
+endif
 
 -include $(top_srcdir)/git.mk

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -50,7 +50,11 @@ plugins_in_in_files = $(plugins_in_files:.desktop.in=.desktop.in.in)
 plugins_DATA = $(plugins_in_files:.plugin.desktop.in=.plugin)
 
 %.plugin: %.plugin.desktop.in
+if USE_NLS
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
+else
+	$(AM_V_GEN) cp $< $@
+endif
 
 DISTCLEANFILES = $(plugins_in_files)
 CLEANFILES = $(plugins_DATA)

--- a/plugins/reload/eom-reload-plugin.c
+++ b/plugins/reload/eom-reload-plugin.c
@@ -119,7 +119,9 @@ eom_reload_plugin_activate (EomWindowActivatable *activatable)
 	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	plugin->ui_action_group = gtk_action_group_new ("EomReloadPluginActions");
 
+#ifdef ENABLE_NLS
 	gtk_action_group_set_translation_domain (plugin->ui_action_group, GETTEXT_PACKAGE);
+#endif /* ENABLE_NLS */
 
 	gtk_action_group_add_actions (plugin->ui_action_group, action_entries,
 	                              G_N_ELEMENTS (action_entries), plugin->window);

--- a/src/eom-save-as-dialog-helper.c
+++ b/src/eom-save-as-dialog-helper.c
@@ -207,7 +207,9 @@ eom_save_as_dialog_new (GtkWindow *main, GList *images, GFile *base_file)
 	GtkWidget *label;
 
 	xml = gtk_builder_new_from_resource ("/org/mate/eom/ui/eom-multiple-save-as-dialog.ui");
+#ifdef ENABLE_NLS
 	gtk_builder_set_translation_domain (xml, GETTEXT_PACKAGE);
+#endif /* ENABLE_NLS */
 
 	dlg = GTK_WIDGET (g_object_ref (gtk_builder_get_object (xml, "eom_multiple_save_as_dialog")));
 	gtk_window_set_transient_for (GTK_WINDOW (dlg), GTK_WINDOW (main));

--- a/src/eom-window.c
+++ b/src/eom-window.c
@@ -4412,8 +4412,10 @@ eom_window_construct_ui (EomWindow *window)
 	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	priv->actions_window = gtk_action_group_new ("MenuActionsWindow");
 
+#ifdef ENABLE_NLS
 	gtk_action_group_set_translation_domain (priv->actions_window,
 						 GETTEXT_PACKAGE);
+#endif /* ENABLE_NLS */
 
 	gtk_action_group_add_actions (priv->actions_window,
 				      action_entries_window,
@@ -4430,8 +4432,10 @@ eom_window_construct_ui (EomWindow *window)
 
 	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	priv->actions_image = gtk_action_group_new ("MenuActionsImage");
+#ifdef ENABLE_NLS
 	gtk_action_group_set_translation_domain (priv->actions_image,
 						 GETTEXT_PACKAGE);
+#endif /* ENABLE_NLS */
 
 	gtk_action_group_add_actions (priv->actions_image,
 				      action_entries_image,
@@ -4450,8 +4454,10 @@ eom_window_construct_ui (EomWindow *window)
 
 	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	priv->actions_collection = gtk_action_group_new ("MenuActionsCollection");
+#ifdef ENABLE_NLS
 	gtk_action_group_set_translation_domain (priv->actions_collection,
 						 GETTEXT_PACKAGE);
+#endif /* ENABLE_NLS */
 
 	gtk_action_group_add_actions (priv->actions_collection,
 				      action_entries_collection,
@@ -4536,8 +4542,10 @@ eom_window_construct_ui (EomWindow *window)
 
 	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	priv->actions_recent = gtk_action_group_new ("RecentFilesActions");
+#ifdef ENABLE_NLS
 	gtk_action_group_set_translation_domain (priv->actions_recent,
 						 GETTEXT_PACKAGE);
+#endif /* ENABLE_NLS */
 	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	g_signal_connect (gtk_recent_manager_get_default (), "changed",

--- a/src/main.c
+++ b/src/main.c
@@ -97,9 +97,11 @@ main (int argc, char **argv)
 	GFile *css_file;
 	GtkCssProvider *provider;
 
+#ifdef ENABLE_NLS
 	bindtextdomain (GETTEXT_PACKAGE, EOM_LOCALE_DIR);
 	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
 	textdomain (GETTEXT_PACKAGE);
+#endif /* ENABLE_NLS */
 
 	gdk_set_allowed_backends ("wayland,x11");
 


### PR DESCRIPTION
### With NLS
```
$ find /usr/share/locale -type f -name 'eom.mo' -exec sudo rm -f {} +
$ find /usr/share/help -type d -name 'eom' -exec sudo rm -fr {} +
$ ./autogen.sh --prefix=/usr && make && sudo make install
$ find /usr/share/locale -type f -name 'eom.mo' -exec du -ch {} + | grep total
2,7M	total
$ find /usr/share/help -type d -name 'eom' -exec du -ch {} + | grep total
6,4M	total
```
### Without NLS
```
$ find /usr/share/locale -type f -name 'eom.mo' -exec sudo rm -f {} +
$ find /usr/share/help -type d -name 'eom' -exec sudo rm -fr {} +
$ ./autogen.sh --prefix=/usr --disable-nls && make && sudo make install
$ find /usr/share/locale -type f -name 'eom.mo' -exec du -ch {} + | grep total
$ find /usr/share/help -type d -name 'eom' -exec du -ch {} + | grep total
124K	total
```
