### PR TITLE
build: Use PACKAGE_URL variable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ m4_define(eom_minor_version, 25)
 m4_define(eom_micro_version, 0)
 m4_define(eom_version, eom_major_version.eom_minor_version.eom_micro_version)
 
-AC_INIT([eom], eom_version, [http://www.mate-desktop.org], [eom])
+AC_INIT([eom], eom_version, https://github.com/mate-desktop/eom/issues, [eom], [https://mate-desktop.org])
 AM_INIT_AUTOMAKE([1.9 foreign no-dist-gzip dist-xz check-news])
 
 # Support silencing the build output if supported (automake-1.11+)
@@ -394,6 +394,7 @@ help/Makefile
 po/Makefile.in
 data/Makefile
 data/eom.pc
+data/eom.appdata.xml.in
 data/eom.desktop.in
 data/org.mate.eom.gschema.xml
 data/pixmaps/Makefile
@@ -403,6 +404,9 @@ doc/reference/Makefile
 doc/reference/version.xml
 doc/reference/eom-docs.sgml
 plugins/Makefile
+plugins/fullscreen/fullscreen.plugin.desktop.in
+plugins/reload/reload.plugin.desktop.in
+plugins/statusbar-date/statusbar-date.plugin.desktop.in
 thumbnailer/Makefile
 thumbnailer/eom-thumbnailer.thumbnailer
 ])

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,16 +1,16 @@
 SUBDIRS = pixmaps icons
 
-DESKTOP_IN_FILES= eom.desktop.in.in
-DESKTOP_FILES= $(DESKTOP_IN_FILES:.desktop.in.in=.desktop)
-
 desktopdir = $(datadir)/applications
-desktop_DATA = $(DESKTOP_FILES)
-$(desktop_DATA): $(DESKTOP_IN_FILES)
+desktop_DATA = eom.desktop
+desktop_in_files = $(desktop_DATA:.desktop=.desktop.in)
+desktop_in_in_files = $(desktop_in_files:.desktop.in=.desktop.in.in)
+$(desktop_DATA): $(desktop_in_files)
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword= --keyword=Name --keyword=Comment --keyword=Keywords --template $< -d $(top_srcdir)/po -o $@
 
 appdatadir = $(datadir)/metainfo
-appdata_in_files = eom.appdata.xml.in
-appdata_DATA = $(appdata_in_files:.xml.in=.xml)
+appdata_DATA = eom.appdata.xml
+appdata_in_files = $(appdata_DATA:.xml=.xml.in)
+appdata_in_in_files = $(appdata_in_files:.xml.in=.xml.in.in)
 $(appdata_DATA): $(appdata_in_files)
 	$(AM_V_GEN) $(MSGFMT) --xml --template $< -d $(top_srcdir)/po -o $@
 
@@ -29,7 +29,7 @@ pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = eom.pc
 
 EXTRA_DIST = \
-	$(ui_DATA) \
+	$(ui_DATA)		\
 	eom.css			\
 	eom-image-properties-dialog.ui	\
 	eom-multiple-save-as-dialog.ui	\
@@ -37,14 +37,16 @@ EXTRA_DIST = \
 	eom-ui.xml		\
 	metadata-sidebar.ui	\
 	eom.about		\
-	$(DESKTOP_IN_FILES) \
-	$(appdata_in_files)
+	$(appdata_in_in_files)	\
+	$(desktop_in_in_files)
 
 CLEANFILES = \
-        $(appdata_DATA)
+	$(appdata_DATA) \
+	$(desktop_DATA)
 
 DISTCLEANFILES = \
-        $(DESKTOP_FILES) \
-        $(gsettings_SCHEMAS)
+	$(appdata_in_files) \
+	$(desktop_in_files) \
+	$(gsettings_SCHEMAS)
 
 -include $(top_srcdir)/git.mk

--- a/data/eom.appdata.xml.in.in
+++ b/data/eom.appdata.xml.in.in
@@ -12,8 +12,8 @@
       subsequent images in the directory the image was loaded from.
     </p>
   </description>
-  <url type="homepage">http://mate-desktop.org/</url>
+  <url type="homepage">@PACKAGE_URL@</url>
   <screenshots>
-    <screenshot type="default">http://mate-desktop.org/gallery/1.8/eom.png</screenshot>
+    <screenshot type="default">https://mate-desktop.org/gallery/1.8/eom.png</screenshot>
   </screenshots>
 </component>

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -46,14 +46,15 @@ endif
 
 # Generate plugin info files
 
+plugins_in_in_files = $(plugins_in_files:.desktop.in=.desktop.in.in)
 plugins_DATA = $(plugins_in_files:.plugin.desktop.in=.plugin)
 
 %.plugin: %.plugin.desktop.in
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
-DISTCLEANFILES = $(plugins_DATA)
+DISTCLEANFILES = $(plugins_in_files)
 CLEANFILES = $(plugins_DATA)
 
-EXTRA_DIST = $(plugins_in_files)
+EXTRA_DIST = $(plugins_in_in_files)
 
 -include $(top_srcdir)/git.mk

--- a/plugins/fullscreen/fullscreen.plugin.desktop.in.in
+++ b/plugins/fullscreen/fullscreen.plugin.desktop.in.in
@@ -6,4 +6,4 @@ Icon=view-fullscreen
 Description=Activate fullscreen mode with double-click
 Authors=Lucas Rocha <lucasr@gnome.org>
 Copyright=Copyright © 2007 Lucas Rocha
-Website=http://www.mate-desktop.org/
+Website=@PACKAGE_URL@

--- a/plugins/reload/reload.plugin.desktop.in.in
+++ b/plugins/reload/reload.plugin.desktop.in.in
@@ -6,4 +6,4 @@ Icon=view-refresh
 Description=Reload current image
 Authors=Lucas Rocha <lucasr@gnome.org>
 Copyright=Copyright © 2007 Lucas Rocha
-Website=http://www.mate-desktop.org/
+Website=@PACKAGE_URL@

--- a/plugins/statusbar-date/statusbar-date.plugin.desktop.in.in
+++ b/plugins/statusbar-date/statusbar-date.plugin.desktop.in.in
@@ -5,4 +5,4 @@ Name=Date in statusbar
 Description=Shows the image date in the window statusbar
 Authors=Claudio Saavedra  <csaavedra@gnome.org>
 Copyright=Copyright © 2008 Free Software Foundation
-Website=http://www.mate-desktop.org/
+Website=@PACKAGE_URL@

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -2,7 +2,7 @@
 # Please keep this file sorted alphabetically.
 cut-n-paste/toolbar-editor/egg-editable-toolbar.c
 cut-n-paste/toolbar-editor/egg-toolbar-editor.c
-data/eom.appdata.xml.in
+data/eom.appdata.xml.in.in
 data/eom.desktop.in.in
 data/eom-image-properties-dialog.ui
 data/eom-multiple-save-as-dialog.ui
@@ -10,10 +10,10 @@ data/eom-preferences-dialog.ui
 data/metadata-sidebar.ui
 data/org.mate.eom.gschema.xml.in
 plugins/fullscreen/eom-fullscreen-plugin.c
-plugins/fullscreen/fullscreen.plugin.desktop.in
+plugins/fullscreen/fullscreen.plugin.desktop.in.in
 plugins/reload/eom-reload-plugin.c
-plugins/reload/reload.plugin.desktop.in
-plugins/statusbar-date/statusbar-date.plugin.desktop.in
+plugins/reload/reload.plugin.desktop.in.in
+plugins/statusbar-date/statusbar-date.plugin.desktop.in.in
 src/eom-application.c
 src/eom-close-confirmation-dialog.c
 src/eom-file-chooser.c

--- a/src/eom-window.c
+++ b/src/eom-window.c
@@ -2636,7 +2636,7 @@ eom_window_cmd_about (GtkAction *action, gpointer user_data)
 			       "authors", authors,
 			       "documenters", documenters,
 			       "translator-credits", _("translator-credits"),
-			       "website", "http://www.mate-desktop.org/",
+			       "website", PACKAGE_URL,
 			       "logo-icon-name", "eom",
 			       "wrap-license", TRUE,
 			       "license", license_trans,


### PR DESCRIPTION
Test:
```
$ grep homepage data/eom.appdata.xml
  <url type="homepage">https://mate-desktop.org</url>
$ find . -name *.plugin -exec grep -H Website {} \;
./plugins/fullscreen/fullscreen.plugin:Website=https://mate-desktop.org
./plugins/reload/reload.plugin:Website=https://mate-desktop.org
./plugins/statusbar-date/statusbar-date.plugin:Website=https://mate-desktop.org
$ grep PACKAGE_URL config.h
#define PACKAGE_URL "https://mate-desktop.org"
```

- Change the url prefix from `http` to `https` of the screenshot in the eom.appdata.xml file, which is used in applications such as `gnome-software` (eom.appdata.xml.in.in)

- Set all [AC_INIT](https://www.gnu.org/software/autoconf/manual/autoconf-2.67/html_node/Initializing-configure.html) fields including optional ones (configure.ac):
```
Macro: AC_INIT (package, version, [bug-report], [tarname], [url])
```

- Use tabs to indent (Makefile.am)
- Sort the variables alphabetically (Makefile.am)
- Write the variables `DESKTOP_*` in lower case (Makefile.am)
- Use bottom-up pattern instead of up-down for replacing the suffix at the end of file names as follows (Makefile.am):

usage:
```
$(var:suffix=replacement)
```
before:
```
appdata_in_files = eom.appdata.xml.in	
appdata_DATA = $(appdata_in_files:.xml.in=.xml)
```
after:
```
appdata_DATA = eom.appdata.xml
appdata_in_files = $(appdata_DATA:.xml=.xml.in)
appdata_in_in_files = $(appdata_in_files:.xml.in=.xml.in.in)
```