### PR TITLE
build: display package name and version in configure summary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -412,6 +412,9 @@ AC_OUTPUT
 echo "
 Configure summary:
 
+	${PACKAGE_STRING}
+	`echo $PACKAGE_STRING | sed "s/./=/g"`
+
 	Source code location .......:  ${srcdir}
 	Compiler ...................:  ${CC}
 	Extra Compiler Warnings ....:  ${WARN_CFLAGS}


### PR DESCRIPTION
```
$ ./autogen.sh --prefix=/usr
<cut>
Configure summary:

	eom 1.25.0
	==========

	Source code location .......:  .
	Compiler ...................:  gcc
	Extra Compiler Warnings ....:  -Wall -Wmissing-prototypes

	EXIF support ...............:  yes
	XMP support ................:  yes
	JPEG support ...............:  yes
	RSVG support ...............:  yes
	Colour management support ..:  yes
	GObject Introspection.......:  yes
	Thumbnailer.................:  no

Now type `make' to compile eom
```