### PR TITLE
Fix desktop file validation warning

### DIFF
--- a/data/eom.desktop.in.in
+++ b/data/eom.desktop.in.in
@@ -8,7 +8,7 @@ Icon=eom
 StartupNotify=true
 Terminal=false
 Type=Application
-Categories=GTK;Graphics;RasterGraphics;Viewer;
+Categories=GTK;Graphics;2DGraphics;RasterGraphics;Viewer;
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 Keywords=image;viewer;JPEG;PNG;TIFF;SVG;MATE;photos;browse;thumbnails;rotate;
 X-MATE-Bugzilla-Bugzilla=MATE


### PR DESCRIPTION
```
$ desktop-file-validate data/eom.desktop 
data/eom.desktop: hint: value item "RasterGraphics" in key "Categories" in group "Desktop Entry" can be extended with another category among the following categories: Graphics;2DGraphics
```