### PR TITLE
WIP main: display application name in command line help

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -96,6 +96,7 @@ main (int argc, char **argv)
 	GOptionContext *ctx;
 	GFile *css_file;
 	GtkCssProvider *provider;
+	gboolean success;
 
 #ifdef ENABLE_NLS
 	bindtextdomain (GETTEXT_PACKAGE, EOM_LOCALE_DIR);
@@ -114,7 +115,11 @@ main (int argc, char **argv)
 	g_option_context_add_group (ctx, g_irepository_get_option_group ());
 #endif
 
-	if (!g_option_context_parse (ctx, &argc, &argv, &error)) {
+	success = g_option_context_parse (ctx, &argc, &argv, &error);
+	g_option_context_free (ctx);
+	g_strfreev (startup_files);
+
+	if (!success) {
 		gchar *help_msg;
 
 		/* I18N: The '%s' is replaced with eom's command name. */
@@ -124,12 +129,9 @@ main (int argc, char **argv)
                 g_printerr ("%s\n%s\n", error->message, help_msg);
                 g_error_free (error);
 		g_free (help_msg);
-                g_option_context_free (ctx);
 
                 return 1;
         }
-	g_option_context_free (ctx);
-
 
 	set_startup_flags ();
 
@@ -174,7 +176,6 @@ main (int argc, char **argv)
 
 	g_application_run (G_APPLICATION (EOM_APP), argc, argv);
 	g_object_unref (EOM_APP);
-	g_strfreev (startup_files);
 
 #ifdef HAVE_EXEMPI
 	xmp_terminate();

--- a/src/main.c
+++ b/src/main.c
@@ -71,8 +71,8 @@ static const GOptionEntry goption_options[] =
 	{ "disable-image-collection", 'c', 0, G_OPTION_ARG_NONE, &disable_collection, N_("Disable image collection"), NULL  },
 	{ "slide-show", 's', 0, G_OPTION_ARG_NONE, &slide_show, N_("Open in slideshow mode"), NULL  },
 	{ "new-instance", 'n', 0, G_OPTION_ARG_NONE, &force_new_instance, N_("Start a new instance instead of reusing an existing one"), NULL },
-	{ "version", 0, G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK,
-	  _print_version_and_exit, N_("Show the application's version"), NULL},
+	{ "version", 0, G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, _print_version_and_exit, N_("Show the application's version"), NULL},
+	{ G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &startup_files, NULL, N_("[FILE…]") },
 	{ NULL }
 };
 
@@ -105,7 +105,7 @@ main (int argc, char **argv)
 
 	gdk_set_allowed_backends ("wayland,x11");
 
-	ctx = g_option_context_new (_("[FILE…]"));
+	ctx = g_option_context_new (_("- Eye of MATE Image Viewer"));
 	g_option_context_add_main_entries (ctx, goption_options, PACKAGE);
 	/* Option groups are free'd together with the context
 	 * Using gtk_get_option_group here initializes gtk during parsing */

--- a/src/main.c
+++ b/src/main.c
@@ -130,7 +130,7 @@ main (int argc, char **argv)
                 g_error_free (error);
 		g_free (help_msg);
 
-                return 1;
+                return EXIT_FAILURE;
         }
 
 	set_startup_flags ();
@@ -180,5 +180,5 @@ main (int argc, char **argv)
 #ifdef HAVE_EXEMPI
 	xmp_terminate();
 #endif
-	return 0;
+	return EXIT_SUCCESS;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -174,9 +174,7 @@ main (int argc, char **argv)
 
 	g_application_run (G_APPLICATION (EOM_APP), argc, argv);
 	g_object_unref (EOM_APP);
-
-  	if (startup_files)
-		g_strfreev (startup_files);
+	g_strfreev (startup_files);
 
 #ifdef HAVE_EXEMPI
 	xmp_terminate();

--- a/src/main.c
+++ b/src/main.c
@@ -106,7 +106,7 @@ main (int argc, char **argv)
 	gdk_set_allowed_backends ("wayland,x11");
 
 	ctx = g_option_context_new (_("- Eye of MATE Image Viewer"));
-	g_option_context_add_main_entries (ctx, goption_options, PACKAGE);
+	g_option_context_add_main_entries (ctx, goption_options, GETTEXT_PACKAGE);
 	/* Option groups are free'd together with the context
 	 * Using gtk_get_option_group here initializes gtk during parsing */
 	g_option_context_add_group (ctx, gtk_get_option_group (TRUE));


### PR DESCRIPTION
Before:
```
$ LANG=C eom --help
Usage:
  eom [OPTION?] [FILE?]

Help Options:
  -h, --help                         Show help options
  --help-all                         Show all help options
  --help-gtk                         Show GTK+ Options

Application Options:
  -f, --fullscreen                   Open in fullscreen mode
  -c, --disable-image-collection     Disable image collection
  -s, --slide-show                   Open in slideshow mode
  -n, --new-instance                 Start a new instance instead of reusing an existing one
  --version                          Show the application's version
  --display=DISPLAY                  X display to use

```
After:
```
$ LANG=C eom --help
Usage:
  eom [OPTION?] [FILE?] - Eye of MATE Image Viewer

Help Options:
  -h, --help                         Show help options
  --help-all                         Show all help options
  --help-gtk                         Show GTK+ Options

Application Options:
  -f, --fullscreen                   Open in fullscreen mode
  -c, --disable-image-collection     Disable image collection
  -s, --slide-show                   Open in slideshow mode
  -n, --new-instance                 Start a new instance instead of reusing an existing one
  --version                          Show the application's version
  --display=DISPLAY                  X display to use

```