### PR TITLE
Accessibility: add proper mnemonic relations and labelling

### DIFF
--- a/data/eom-image-properties-dialog.ui
+++ b/data/eom-image-properties-dialog.ui
@@ -145,6 +145,7 @@
                             <property name="margin-top">8</property>
                             <property name="margin-bottom">8</property>
                             <property name="label" translatable="yes">Name:</property>
+                            <property name="mnemonic-widget">name_label</property>
                             <property name="justify">right</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
@@ -164,6 +165,7 @@
                             <property name="margin-top">8</property>
                             <property name="margin-bottom">8</property>
                             <property name="label" translatable="yes">Width:</property>
+                            <property name="mnemonic-widget">width_label</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
                             </attributes>
@@ -182,6 +184,7 @@
                             <property name="margin-top">8</property>
                             <property name="margin-bottom">8</property>
                             <property name="label" translatable="yes">Height:</property>
+                            <property name="mnemonic-widget">height_label</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
                             </attributes>
@@ -200,6 +203,7 @@
                             <property name="margin-top">8</property>
                             <property name="margin-bottom">8</property>
                             <property name="label" translatable="yes">Type:</property>
+                            <property name="mnemonic-widget">type_label</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
                             </attributes>
@@ -218,6 +222,7 @@
                             <property name="margin-top">8</property>
                             <property name="margin-bottom">8</property>
                             <property name="label" translatable="yes">Bytes:</property>
+                            <property name="mnemonic-widget">bytes_label</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
                             </attributes>
@@ -236,6 +241,7 @@
                             <property name="margin-top">8</property>
                             <property name="margin-bottom">8</property>
                             <property name="label" translatable="yes">Location:</property>
+                            <property name="mnemonic-widget">folder_button</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
                             </attributes>

--- a/data/eom-preferences-dialog.ui
+++ b/data/eom-preferences-dialog.ui
@@ -277,6 +277,11 @@
                             <property name="can-focus">True</property>
                             <property name="receives-default">True</property>
                             <property name="title" translatable="yes">Background Color</property>
+                            <child internal-child="accessible">
+                              <object class="AtkObject" id="bg_color_accessible">
+                                <property name="AtkObject::accessible-name" translatable="yes">Background Color</property>
+                              </object>
+                            </child>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -388,6 +393,11 @@
                                     <property name="use-alpha">True</property>
                                     <property name="title" translatable="yes">Color for Transparent Areas</property>
                                     <property name="rgba">rgb(0,0,0)</property>
+                                    <child internal-child="accessible">
+                                      <object class="AtkObject" id="transp_color_accessible">
+                                        <property name="AtkObject::accessible-name" translatable="yes">Color for Transparent Areas</property>
+                                      </object>
+                                    </child>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -609,6 +619,11 @@
                                     <property name="adjustment">adjustment1</property>
                                     <property name="climb-rate">1</property>
                                     <property name="numeric">True</property>
+                                    <child internal-child="accessible">
+                                      <object class="AtkObject">
+                                        <property name="AtkObject::accessible-name" translatable="yes">seconds</property>
+                                      </object>
+                                    </child>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>


### PR DESCRIPTION
Unfortunately, there’s a [GTK bug](https://gitlab.gnome.org/GNOME/gtk/-/issues/4339) that prevents the status bar from  
being fully accessible, but at least this will make the Info and Preferences  
dialogs a bit easier to navigate.