### PR TITLE
Add support for libexif 0.6.14+

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -141,7 +141,7 @@ fi
 # EXIF (optional)
 # ***************
 
-LIBEXIF_REQUIRED=0.6.22
+LIBEXIF_REQUIRED=0.6.14
 
 AC_ARG_WITH([libexif], AC_HELP_STRING([--without-libexif], [disable EXIF support]))
 have_exif=no


### PR DESCRIPTION
libexif 0.6.22+ was previously required because the macro
EXIF_TAG_GAMMA was not defined reading the NEWS file.