### PR TITLE
explicitly assigning value of variable of type 'int' to itself

### DIFF
--- a/src/eom-scroll-view.c
+++ b/src/eom-scroll-view.c
@@ -1032,12 +1032,12 @@ eom_scroll_view_scroll_event (GtkWidget *widget, GdkEventScroll *event, gpointer
 	case GDK_SCROLL_DOWN:
 		zoom_factor = 1.0 / priv->zoom_multiplier;
 		xofs = 0;
-		yofs = yofs;
+		/* yofs = yofs; */
 		break;
 
 	case GDK_SCROLL_RIGHT:
 		zoom_factor = priv->zoom_multiplier;
-		xofs = xofs;
+		/* xofs = xofs; */
 		yofs = 0;
 		break;
 


### PR DESCRIPTION
```
eom-scroll-view.c:1035:8: warning: explicitly assigning value of variable of type 'int' to itself [-Wself-assign]
                yofs = yofs;
                ~~~~ ^ ~~~~
eom-scroll-view.c:1040:8: warning: explicitly assigning value of variable of type 'int' to itself [-Wself-assign]
                xofs = xofs;
                ~~~~ ^ ~~~~
```