### PR TITLE
eom-window: fix warning incompatible-pointer-types

### DIFF
--- a/src/eom-window.c
+++ b/src/eom-window.c
@@ -4343,7 +4343,7 @@ eom_window_open_editor (GtkAction *action,
 	file = eom_image_get_file (window->priv->image);
 	files = g_list_append (files, file);
 
-	g_app_info_launch (app_info, &files,
+	g_app_info_launch (app_info, files,
                            G_APP_LAUNCH_CONTEXT (context), NULL);
 
 	g_list_free (files);


### PR DESCRIPTION
```
eom-window.c:4346:31: warning: incompatible pointer types passing 'GList **' (aka 'struct _GList **') to parameter of type 'GList *' (aka 'struct _GList *'); remove & [-Wincompatible-pointer-types]
        g_app_info_launch (app_info, &files,
                                     ^~~~~~
/usr/include/glib-2.0/gio/gappinfo.h:175:76: note: passing argument to parameter 'files' here
                                                     GList                *files,
                                                                           ^
```
Test:
- set default editor
```
gsettings set org.mate.eom.ui external-editor /usr/share/applications/gimp.desktop
```
- add "Edit Image" toobar button if not present: right clic on toolbar, click on Toolbar menu item, drag & drop "Edit Image".

<img width="918" alt="Captura de Pantalla 2021-10-21 a les 11 56 12" src="https://user-images.githubusercontent.com/10171411/138255255-f5f10fc7-0768-411e-bb15-cc2462aaf8af.png">

- click on "Edit Image" toobar button

<img width="702" alt="Captura de Pantalla 2021-10-21 a les 11 38 02" src="https://user-images.githubusercontent.com/10171411/138252361-19c40fbc-818d-4c53-9283-ea6f5f8cb766.png">
