### PR TITLE
eom-window: variable is assigned a value that is never used

### DIFF
--- a/src/eom-window.c
+++ b/src/eom-window.c
@@ -574,7 +574,6 @@ update_action_groups_state (EomWindow *window)
 	GtkAction *action_sshow;
 	GtkAction *action_print;
 	gboolean print_disabled = FALSE;
-	gboolean show_image_collection = FALSE;
 	gint n_images = 0;
 
 	g_return_if_fail (EOM_IS_WINDOW (window));
@@ -633,6 +632,8 @@ update_action_groups_state (EomWindow *window)
 			priv->status = EOM_WINDOW_STATUS_NORMAL;
 		}
 	} else {
+		gboolean show_image_collection;
+
 		if (priv->flags & EOM_STARTUP_DISABLE_COLLECTION) {
 			g_settings_set_boolean (priv->ui_settings, EOM_CONF_UI_IMAGE_COLLECTION, FALSE);
 

--- a/src/eom-window.c
+++ b/src/eom-window.c
@@ -4686,7 +4686,9 @@ static void
 eom_window_init (EomWindow *window)
 {
 	GdkGeometry hints;
+#if defined(HAVE_LCMS) && defined(GDK_WINDOWING_X11)
 	GdkScreen *screen;
+#endif
 	EomWindowPrivate *priv;
 
 	eom_debug (DEBUG_WINDOW);
@@ -4698,8 +4700,6 @@ eom_window_init (EomWindow *window)
 
 	hints.min_width  = EOM_WINDOW_MIN_WIDTH;
 	hints.min_height = EOM_WINDOW_MIN_HEIGHT;
-
-	screen = gtk_widget_get_screen (GTK_WIDGET (window));
 
 	priv = window->priv = eom_window_get_instance_private (window);
 
@@ -4738,6 +4738,7 @@ eom_window_init (EomWindow *window)
 	window->priv->status = EOM_WINDOW_STATUS_UNKNOWN;
 
 #if defined(HAVE_LCMS) && defined(GDK_WINDOWING_X11)
+	screen = gtk_widget_get_screen (GTK_WIDGET (window));
 	window->priv->display_profile =
 		eom_window_get_display_profile (screen);
 #endif


### PR DESCRIPTION
Fix the cppcheck warning:
```
cppcheck --enable=all --quiet .
```
```
src/eom-window.c:4702:9: style: Variable 'screen' is assigned a value that is never used. [unreadVariable]
 screen = gtk_widget_get_screen (GTK_WIDGET (window));
        ^
```
```
src/eom-window.c:577:33: style: Variable 'show_image_collection' is assigned a value that is never used. [unreadVariable]
 gboolean show_image_collection = FALSE;
                                ^
```