### PR TITLE
Updated url in readme to point to working link

### DIFF
--- a/README
+++ b/README
@@ -57,7 +57,7 @@ Webpage
 -------
 
 You can find screenshots and the latest news about 'Eye of MATE' in
-http://wiki.mate-desktop.org/doku.php/applications:eom.
+https://wiki.mate-desktop.org/mate-desktop/applications/eom/.
 
 
 Reporting bugs


### PR DESCRIPTION
It looks like the wiki's URL format has changed. Just a small change to point to the modern format.