### PR TITLE
Fix some build warnings about bad function cast

### DIFF
--- a/src/eom-close-confirmation-dialog.c
+++ b/src/eom-close-confirmation-dialog.c
@@ -451,8 +451,6 @@ populate_model (GtkTreeModel *store, GList *imgs)
 		const gchar *name;
 		GdkPixbuf *buf = NULL;
 		GdkPixbuf *buf_scaled = NULL;
-		int width;
-		double ratio;
 
 		img = EOM_IMAGE (imgs->data);
 
@@ -460,9 +458,17 @@ populate_model (GtkTreeModel *store, GList *imgs)
 		buf = eom_image_get_thumbnail (img);
 
 		if (buf) {
-			ratio = IMAGE_COLUMN_HEIGHT / (double) gdk_pixbuf_get_height (buf);
-			width = (int) (gdk_pixbuf_get_width (buf) * ratio);
-			buf_scaled = gdk_pixbuf_scale_simple (buf, width, IMAGE_COLUMN_HEIGHT, GDK_INTERP_BILINEAR);
+			int height;
+			int width;
+			double ratio;
+
+			height = gdk_pixbuf_get_height (buf);
+			ratio = IMAGE_COLUMN_HEIGHT / (double) height;
+			width = gdk_pixbuf_get_width (buf);
+			buf_scaled = gdk_pixbuf_scale_simple (buf,
+			                                      (int) (ratio * (double) width),
+			                                      IMAGE_COLUMN_HEIGHT,
+			                                      GDK_INTERP_BILINEAR);
 		} else
 			buf_scaled = get_nothumb_pixbuf ();
 

--- a/src/eom-scroll-view.c
+++ b/src/eom-scroll-view.c
@@ -1294,7 +1294,8 @@ display_draw (GtkWidget *widget, cairo_t *cr, gpointer data)
 		cairo_matrix_init_identity (&matrix);
 		if (transform) {
 			cairo_matrix_t affine;
-			double image_offset_x = 0., image_offset_y = 0.;
+			int image_offset_x = 0;
+			int image_offset_y = 0;
 
 			eom_transform_get_affine (transform, &affine);
 			cairo_matrix_multiply (&matrix, &affine, &matrix);
@@ -1302,23 +1303,23 @@ display_draw (GtkWidget *widget, cairo_t *cr, gpointer data)
 			switch (eom_transform_get_transform_type (transform)) {
 			case EOM_TRANSFORM_ROT_90:
 			case EOM_TRANSFORM_FLIP_HORIZONTAL:
-				image_offset_x = (double) gdk_pixbuf_get_width (priv->pixbuf);
+				image_offset_x = gdk_pixbuf_get_width (priv->pixbuf);
 				break;
 			case EOM_TRANSFORM_ROT_270:
 			case EOM_TRANSFORM_FLIP_VERTICAL:
-				image_offset_y = (double) gdk_pixbuf_get_height (priv->pixbuf);
+				image_offset_y = gdk_pixbuf_get_height (priv->pixbuf);
 				break;
 			case EOM_TRANSFORM_ROT_180:
 			case EOM_TRANSFORM_TRANSPOSE:
 			case EOM_TRANSFORM_TRANSVERSE:
-				image_offset_x = (double) gdk_pixbuf_get_width (priv->pixbuf);
-				image_offset_y = (double) gdk_pixbuf_get_height (priv->pixbuf);
+				image_offset_x = gdk_pixbuf_get_width (priv->pixbuf);
+				image_offset_y = gdk_pixbuf_get_height (priv->pixbuf);
 				break;
 			case EOM_TRANSFORM_NONE:
 				default:
 				break;
 			}
-			cairo_matrix_init_translate (&translate, image_offset_x, image_offset_y);
+			cairo_matrix_init_translate (&translate, (double) image_offset_x, (double) image_offset_y);
 			cairo_matrix_multiply (&matrix, &matrix, &translate);
 		}
 		/* Zoom factor for SVGs is already scaled, so scale back to application pixels. */


### PR DESCRIPTION
```
eom-scroll-view.c:1305:31: warning: cast from function call of type 'int' to non-matching type 'double' [-Wbad-function-cast]
                                image_offset_x = (double) gdk_pixbuf_get_width (priv->pixbuf);
                                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
eom-scroll-view.c:1309:31: warning: cast from function call of type 'int' to non-matching type 'double' [-Wbad-function-cast]
                                image_offset_y = (double) gdk_pixbuf_get_height (priv->pixbuf);
                                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
eom-scroll-view.c:1314:31: warning: cast from function call of type 'int' to non-matching type 'double' [-Wbad-function-cast]
                                image_offset_x = (double) gdk_pixbuf_get_width (priv->pixbuf);
                                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
eom-scroll-view.c:1315:31: warning: cast from function call of type 'int' to non-matching type 'double' [-Wbad-function-cast]
                                image_offset_y = (double) gdk_pixbuf_get_height (priv->pixbuf);
                                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
--
eom-close-confirmation-dialog.c:463:43: warning: cast from function call of type 'int' to non-matching type 'double' [-Wbad-function-cast]
                        ratio = IMAGE_COLUMN_HEIGHT / (double) gdk_pixbuf_get_height (buf);
                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```