### PR TITLE
Fix building with ImageMagick 7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -318,16 +318,16 @@ if test "x$enable_thumbnailer" != "xno"; then
 
 		CPPFLAGS_save="$CPPFLAGS"
 		CPPFLAGS="$CPPFLAGS $MAGICK_CFLAGS"
-		AC_CHECK_HEADER([wand/MagickWand.h],
-			[have_im6="yes"],
-			[AC_CHECK_HEADER([MagickWand/MagickWand.h], [have_im7="yes"])])
+		AC_CHECK_HEADER([MagickWand/MagickWand.h],
+			[have_im7="yes"],
+			[AC_CHECK_HEADER([wand/MagickWand.h], [have_im6="yes"])])
 		CPPFLAGS="$CPPFLAGS_save"
 
-		if test "x$have_im6" = "xyes"; then
-			 AC_DEFINE(HAVE_IMAGEMAGICK6,1, [Have ImageMagick 6])
-		fi
 		if test "x$have_im7" = "xyes"; then
 			AC_DEFINE(HAVE_IMAGEMAGICK7,1, [Have ImageMagick 7])
+		fi
+		if test "x$have_im6" = "xyes"; then
+			AC_DEFINE(HAVE_IMAGEMAGICK6,1, [Have ImageMagick 6])
 		fi
 
 		THUMBNAILER_CFLAGS="$CFLAGS $GLIB_CFLAGS $GIO_CFLAGS $MAGICK_CFLAGS"


### PR DESCRIPTION
Check for ImageMagick 7 first, then for ImageMagick 6. Original (the reversed) ordering might lead accidentially to `HAVE_IMAGEMAGICK6` with ImageMagick 7.

Build failure at Fedora 38 (with ImageMagick 7): https://koji.fedoraproject.org/koji/buildinfo?buildID=2107065

Successful builds with this pull request applied at:
  - Fedora 38 (with ImageMagick 7): https://koji.fedoraproject.org/koji/taskinfo?taskID=95943021
  - Rocky Linux (with ImageMagick 6): https://koji.fedoraproject.org/koji/taskinfo?taskID=95943024

Pull request results from https://bugzilla.redhat.com/show_bug.cgi?id=2159313 since ImageMagick 7 landed in Fedora Rawhide.