### PR TITLE
fix building with new libxml 2.12.0

### DIFF
--- a/cut-n-paste/toolbar-editor/egg-toolbars-model.c
+++ b/cut-n-paste/toolbar-editor/egg-toolbars-model.c
@@ -27,7 +27,8 @@
 
 #include <unistd.h>
 #include <string.h>
-#include <libxml/xmlsave.h>
+#include <libxml/globals.h>
+#include <libxml/parser.h>
 #include <libxml/tree.h>
 #include <gdk/gdk.h>
 

--- a/cut-n-paste/toolbar-editor/egg-toolbars-model.c
+++ b/cut-n-paste/toolbar-editor/egg-toolbars-model.c
@@ -27,6 +27,7 @@
 
 #include <unistd.h>
 #include <string.h>
+#include <libxml/xmlsave.h>
 #include <libxml/tree.h>
 #include <gdk/gdk.h>
 


### PR DESCRIPTION
Added include <libxml/xmlsave.h> to allow build with libxml 2.12.0.

This PR fixes buid issue with libxml 2.12.0
```console
make[4]: Entering directory '/home/tkloczko/rpmbuild/BUILD/eom-1.27.1/cut-n-paste/toolbar-editor'
  CC       libtoolbareditor_la-egg-toolbars-model.lo
egg-toolbars-model.c: In function 'egg_toolbars_model_to_xml':
egg-toolbars-model.c:78:3: error: 'xmlIndentTreeOutput' undeclared (first use in this function)
   78 |   xmlIndentTreeOutput = TRUE;
      |   ^~~~~~~~~~~~~~~~~~~
egg-toolbars-model.c:78:3: note: each undeclared identifier is reported only once for each function it appears in
egg-toolbars-model.c: In function 'egg_toolbars_model_load_toolbars':
egg-toolbars-model.c:591:9: warning: implicit declaration of function 'xmlParseFile'; did you mean 'xmlSaveFile'? [-Wimplicit-function-declaration]
  591 |   doc = xmlParseFile (xml_file);
      |         ^~~~~~~~~~~~
      |         xmlSaveFile
egg-toolbars-model.c:591:7: warning: assignment to 'xmlDocPtr' {aka 'struct _xmlDoc *'} from 'int' makes pointer from integer without a cast [-Wint-conversion]
  591 |   doc = xmlParseFile (xml_file);
      |       ^
egg-toolbars-model.c: In function 'egg_toolbars_model_load_names':
egg-toolbars-model.c:655:7: warning: assignment to 'xmlDocPtr' {aka 'struct _xmlDoc *'} from 'int' makes pointer from integer without a cast [-Wint-conversion]
  655 |   doc = xmlParseFile (xml_file);
      |       ^
make[4]: *** [Makefile:574: libtoolbareditor_la-egg-toolbars-model.lo] Error 1
```