### PR TITLE
eom-window: update image counter even if current thumbnail is for failed image

### DIFF
--- a/src/eom-window.c
+++ b/src/eom-window.c
@@ -496,38 +496,40 @@ update_status_bar (EomWindow *window)
 
 	priv = window->priv;
 
-	if (priv->image != NULL &&
-	    eom_image_has_data (priv->image, EOM_IMAGE_DATA_DIMENSION)) {
-		int zoom, width, height;
-		goffset bytes = 0;
+	if (priv->image != NULL)
+	{
+		if ( eom_image_has_data (priv->image, EOM_IMAGE_DATA_DIMENSION))
+		{
+			int zoom, width, height;
+			goffset bytes = 0;
 
-		zoom = floor (100 * eom_scroll_view_get_zoom (EOM_SCROLL_VIEW (priv->view)) + 0.5);
+			zoom = floor (100 * eom_scroll_view_get_zoom (EOM_SCROLL_VIEW (priv->view)) + 0.5);
 
-		eom_image_get_size (priv->image, &width, &height);
+			eom_image_get_size (priv->image, &width, &height);
 
-		bytes = eom_image_get_bytes (priv->image);
+			bytes = eom_image_get_bytes (priv->image);
 
-		if ((width > 0) && (height > 0)) {
-			char *size_string;
+			if ((width > 0) && (height > 0)) {
+				char *size_string;
 
-				size_string = g_format_size (bytes);
+					size_string = g_format_size (bytes);
 
-			/* Translators: This is the string displayed in the statusbar
-			 * The tokens are from left to right:
-			 * - image width
-			 * - image height
-			 * - image size in bytes
-			 * - zoom in percent */
-			str = g_strdup_printf (ngettext("%i × %i pixel  %s    %i%%",
-							"%i × %i pixels  %s    %i%%", height),
-						width,
-						height,
-						size_string,
-						zoom);
+				/* Translators: This is the string displayed in the statusbar
+				 * The tokens are from left to right:
+				 * - image width
+				 * - image height
+				 * - image size in bytes
+				 * - zoom in percent */
+				str = g_strdup_printf (ngettext("%i × %i pixel  %s    %i%%",
+								"%i × %i pixels  %s    %i%%", height),
+							width,
+							height,
+							size_string,
+							zoom);
 
-			g_free (size_string);
+				g_free (size_string);
+			}
 		}
-
 		update_image_pos (window);
 	}
 


### PR DESCRIPTION
To reproduce:

* obtain/create an image file, foo.png
* obtain/create unsupported (gdk pixbuf) file, foo.txt
* run `eom foo.png foo.txt`
   * displays foo.png, showing 1/2 in bottom right statusbar:
![image](https://github.com/mate-desktop/eom/assets/18466811/1361e536-785e-46de-beb2-865df4afd6b5)
* navigate to 2nd file which is an invalid (image) file
   * `eom` displays _"Could not load image 'foo.txt'"_ 
   * status bar continues to incorrectly show "1/2", referencing the previous file
![image](https://github.com/mate-desktop/eom/assets/18466811/f2c0073c-3d33-4adc-9d48-be989e42eb4b)

Post fix:
* as above, navigate to 2nd file which is invalid:
![image](https://github.com/mate-desktop/eom/assets/18466811/aa62a61e-0a56-429c-bc5d-f62c8f2c5f89)
