### PR TITLE
CI: release - create tarball with autotools (distcheck)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         run: sudo .github/workflows/ubuntu.sh
 
       - name: Build the source code
-        run: .github/workflows/builds.sh meson
+        run: .github/workflows/builds.sh autotools
 
       - name: Install GH CLI
         uses: dev-hanz-ops/install-gh-cli-action@v0.2.1
@@ -30,6 +30,6 @@ jobs:
 
       - name: Create github release
         run: |
-          gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --generate-notes _build/meson-dist/*
+          gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --generate-notes eom*.tar.xz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Not sure how to test it, but it's the same way like pluma CI handle it.
In result release xz tarball comes with generated files for building with autotools, same like MATE release before.
No prob if you want to use meson dist in general, user can generate those files easily for themself. Than close this PR.
But all MATE packages should handle this in a same way........ihmo.