### PR TITLE
Add null checks for content type with remote files

### DIFF
--- a/src/eom-list-store.c
+++ b/src/eom-list-store.c
@@ -477,7 +477,8 @@ directory_visit (GFile *directory,
 
 	if (!g_str_has_prefix (name, ".")) {
 		/* We support opening any image type, so let eom to add any images in the current directory to the store */
-		if (g_content_type_is_mime_type (mime_type, "image/*") || eom_image_is_supported_mime_type (mime_type)) {
+		if (mime_type != NULL &&
+		    (g_content_type_is_mime_type (mime_type, "image/*") || eom_image_is_supported_mime_type (mime_type))) {
 			load_uri = TRUE;
 		}
 	}

--- a/src/eom-metadata-sidebar.c
+++ b/src/eom-metadata-sidebar.c
@@ -167,7 +167,11 @@ eom_metadata_sidebar_update_general_section (EomMetadataSidebar *sidebar)
 		const gchar *mime_str;
 
 		mime_str = eom_util_get_content_type_with_fallback (file_info);
-		str = g_content_type_get_description (mime_str);
+		if (mime_str != NULL) {
+			str = g_content_type_get_description (mime_str);
+		} else {
+			str = g_strdup (_("Unknown"));
+		}
 		g_object_unref (file_info);
 	}
 	gtk_label_set_text (GTK_LABEL (priv->type_label), str);

--- a/src/eom-properties-dialog.c
+++ b/src/eom-properties-dialog.c
@@ -180,7 +180,11 @@ pd_update_general_tab (EomPropertiesDialog *prop_dlg,
 		type_str = g_strdup (_("Unknown"));
 	} else {
 		mime_str = eom_util_get_content_type_with_fallback (file_info);
-		type_str = g_content_type_get_description (mime_str);
+		if (mime_str != NULL) {
+			type_str = g_content_type_get_description (mime_str);
+		} else {
+			type_str = g_strdup (_("Unknown"));
+		}
 		g_object_unref (file_info);
 	}
 

--- a/src/eom-window.c
+++ b/src/eom-window.c
@@ -748,6 +748,15 @@ add_file_to_recent_files (GFile *file)
 	recent_data->display_name = NULL;
 	recent_data->description = NULL;
 	recent_data->mime_type = (gchar *) eom_util_get_content_type_with_fallback (file_info);
+
+	/* mime_type is required by GTK, so bail out if we couldn't determine it */
+	if (recent_data->mime_type == NULL) {
+		g_slice_free (GtkRecentData, recent_data);
+		g_free (text_uri);
+		g_object_unref (file_info);
+		return FALSE;
+	}
+
 	recent_data->app_name = EOM_RECENT_FILES_APP_NAME;
 	recent_data->app_exec = g_strjoin(" ", g_get_prgname (), "%u", NULL);
 	recent_data->groups = groups;


### PR DESCRIPTION
Adds NULL checks when content-type attributes are missing from GVFS backends. This prevents a crash when opening images from remote filesystems where both standard and fast content-type attributes are missing.

Fixes #366